### PR TITLE
Removing check-yaml precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--maxkb=1024]
       - id: debug-statements
       - id: check-byte-order-marker
-      - id: check-yaml
+#      - id: check-yaml
 
   - repo: https://github.com/psf/black
     rev: 19.10b0


### PR DESCRIPTION
check-yaml is not compatible with the hyperyaml files used in some recipes