### PR TITLE
Ns rse/17 contributing

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+claritychallengecontact@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,10 @@ documentation useful.
 
 ## Contributing Code
 
-If you have algorithms or code that you would like to contribute then please get in touch by emailing us at [claritychallengecontact@gmail.com](mailto:claritychallengecontact@gmail.com). We will be happy to help you integrate your contribution into the Clarity framework; we can even help translate contributions from other languages, e.g. MATLAB.
+If you have algorithms or code that you would like to contribute then please get in touch by emailing us at
+[claritychallengecontact@gmail.com](mailto:claritychallengecontact@gmail.com). We will be happy to help you integrate
+your contribution into the Clarity framework; we can even help translate contributions from other languages, e.g. MATLAB.
+
 
 You are also very welcome to [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and address bugs
 and features yourself and then create a [pull request from the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,4 +62,17 @@ For information on how to configure some popular IDEs see the following links.
 
 
 Further we have implemented a [`pre-commit`](https://pre-commit.com/) hook to ensure flake8 and isort are applied each
-time you make a commit.
+time you make a commit. Whilst the `pre-commit` package will have been installed in your environment when you need to
+install the configured hooks (which are defined in
+[`.precommit-config.yaml`](https://github.com/claritychallenge/clarity/blob/main/.pre-commit-config.yaml)) in your local
+repository. To do so run the following from the `clarity` directory...
+
+``` bash
+pre-commit install
+```
+
+This installs `.git/hooks/pre-commit` commit hook which is triggered each time you make a new commit. When run this will
+automatically lint your code with flake8 and isort so please check the changes carefully.
+
+If your commit fails to pass the checks please read the error messages carefully to find out what has changed and what
+you need to manually fix.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,65 @@
+# Contributing to Clarity
+
+
+## Using Clarity
+
+You can contribute to the development of Clarity simply by using it. If something isn't clear then please do ask
+questions in the [Discussion](). If you find errors when running the code then please report them using the [Issues Bug
+Template](), or if there is a feature or improvement you think Clarity would benefit from then suggest it using the
+[Issues Feature Template]().
+
+If you are new to GitHub and working collaboratively you may find the [GitHub Issues](https://docs.github.com/en/issues)
+documentation useful.
+
+## Contributing Code
+
+You are welcome to [fork]() the repository and address bugs and features yourself and then create a [pull request](),
+however there are a number of practices and standards we ask that you adhere to in order to maintain the quality and
+maintainability of the code base.
+
+### Use a Virtual Environment
+
+It is recommended that you use a [Virtual Environment]().
+
+### Install Development Dependencies
+
+Before undertaking development you should install the development requirements defined by Clarity.  To do so you can do one
+of the following
+
+``` bash
+# Install from Pip
+pip install clarity.[dev]
+# Install from GitHub using Pip
+pip install git+ssh://github.com:claritychallenge/clarity.[dev]
+# Install from local Git repository
+pip install '.[dev]'
+```
+
+### Create an issue
+
+Before undertaking any development please create an [Issue]() for it here on the Clarity repository. There are templates
+for [Bug Reports]() and [Feature Requests](). This allows maintainers to keep an overview of what work is being
+undertaken and gives you the opportunity to discuss with them your intended solutions.
+
+### Create a Fork
+
+Once you have created an issue you can
+[fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) the
+Clarity repository to your own account and create a branch on which to undertake development.
+
+
+### Coding Style
+
+We ask that you adhere to the [PEP8](https://pep8.org/) coding style when writing your code. To facilitate this we use
+[flake8](https://flake8.pycqa.org/en/latest/) and [isort](https://pycqa.github.io/isort/). Most popular Integrated
+Development Environments (IDEs) include plugins that will apply flake8 to your code on saving a file.
+
+For information on how to configure some popular IDEs see the following links.
+
+* [Linting Python in Visual Studio Code](https://code.visualstudio.com/docs/python/linting)
+* [Flake8 support - PyCharm Plugin](https://plugins.jetbrains.com/plugin/11563-flake8-support)
+* [Emacs flymake-python-pyflakes](https://github.com/purcell/flymake-python-pyflakes/)
+
+
+Further we have implemented a [`pre-commit`](https://pre-commit.com/) hook to ensure flake8 and isort are applied each
+time you make a commit.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,7 @@
 # Contributing to Clarity
 
+We welcome and encourage you to contribute to the development of the Clarity code base. These guidelines outline how you
+can do so.
 
 ## Using Clarity
 
@@ -13,13 +15,16 @@ documentation useful.
 
 ## Contributing Code
 
-You are welcome to [fork]() the repository and address bugs and features yourself and then create a [pull request](),
-however there are a number of practices and standards we ask that you adhere to in order to maintain the quality and
+You are welcome to [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and address bugs
+and features yourself and then create a [pull request from the
+fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+However, there are a number of practices and standards we ask that you adhere to in order to maintain the quality and
 maintainability of the code base.
 
 ### Use a Virtual Environment
 
-It is recommended that you use a [Virtual Environment]().
+It is recommended that you use a [Virtual Environment](https://realpython.com/python-virtual-environments-a-primer/) to
+undertake development.
 
 ### Install Development Dependencies
 
@@ -37,9 +42,14 @@ pip install '.[dev]'
 
 ### Create an issue
 
-Before undertaking any development please create an [Issue]() for it here on the Clarity repository. There are templates
-for [Bug Reports]() and [Feature Requests](). This allows maintainers to keep an overview of what work is being
-undertaken and gives you the opportunity to discuss with them your intended solutions.
+Before undertaking any development please create an [Issue](https://github.com/claritychallenge/clarity/issues) for it
+here on the Clarity repository. There are templates for [Bug
+Reports](https://github.com/claritychallenge/clarity/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D)
+and [Feature
+Requests](https://github.com/claritychallenge/clarity/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D). This
+allows maintainers to keep an overview of what work is being undertaken and gives you the opportunity to discuss with
+them your intended solutions.
+
 
 ### Create a Fork
 
@@ -76,3 +86,19 @@ automatically lint your code with flake8 and isort so please check the changes c
 
 If your commit fails to pass the checks please read the error messages carefully to find out what has changed and what
 you need to manually fix.
+
+
+### Testing
+
+All new code should be covered by [unit
+tests](https://carpentries-incubator.github.io/python-testing/04-units/index.html) with at least 70% coverage and where
+appropriate [regression tests](https://carpentries-incubator.github.io/python-testing/07-integration/index.html). This
+includes bug fixes, when a test should be added that captures the bug.
+
+The [pytest](https://docs.pytest.org/en/7.1.x/) framework is used and the conventions are followed under
+Clarity. Tests reside under the `tests` directory (and optionally within a module directory), fixtures should be defined
+in `conftest.py` files whilst resources used should be placed under `tests/resources`.
+
+The Continuous Integration in place on GitHub Actions runs `pytest` on newly created pull-requests and these have to
+pass successfully before merging so it is useful to ensure they pass before you create pull requests at the very
+least. Sometimes it may be sensible to run them against commits too.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,9 @@ documentation useful.
 
 ## Contributing Code
 
-You are welcome to [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and address bugs
+If you have algorithms or code that you would like to contribute then please get in touch by emailing us at [claritychallengecontact@gmail.com](mailto:claritychallengecontact@gmail.com). We will be happy to help you integrate your contribution into the Clarity framework; we can even help translate contributions from other languages, e.g. MATLAB.
+
+You are also very welcome to [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and address bugs
 and features yourself and then create a [pull request from the
 fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
 However, there are a number of practices and standards we ask that you adhere to in order to maintain the quality and


### PR DESCRIPTION
Resolves #17 

Adds `docs/CONTRIBUTING.md` guidelines and moves `CODE_OF_CONDUCT.md` to `docs/CODE_OF_CONDUCT.md`.

These will in due course be included automatically in the GitHub pages documentation (#16).