### PR TITLE
Fixed coverage config in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,6 +102,8 @@ omit =
   *conftest.py
   *tests*
   **/__init__*
+source =
+    clarity
 
 # FIXME : Is an entry_point required (https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
 # [options.entry_points]


### PR DESCRIPTION
This fix so that pytest-cov reports on all source files, not just those imported in tests.