### PR TITLE
Fix cpc1/e029 n_ensembles

### DIFF
--- a/recipes/cpc1/e029_sheffield/infer.py
+++ b/recipes/cpc1/e029_sheffield/infer.py
@@ -61,6 +61,7 @@ class ASR(sb.core.Brain):
 
         self.test_search = S2STransformerBeamSearch(
             modules=test_search_modules,
+            n_ensembles=self.hparams.n_ensembles,
             bos_index=self.hparams.bos_index,
             eos_index=self.hparams.eos_index,
             blank_index=self.hparams.blank_index,
@@ -70,9 +71,9 @@ class ASR(sb.core.Brain):
             ctc_weight=self.hparams.ctc_weight_decode,
             lm_weight=self.hparams.lm_weight,
             lm_modules=self.hparams.lm_model,
-            temperature=1,
+            temperature=self.hparams.temperature,
             temperature_lm=1,
-            topk=10,
+            topk=self.hparams.topk,
             using_eos_threshold=False,
             length_normalization=True,
         )

--- a/recipes/cpc1/e029_sheffield/transformer_cpc1.yaml
+++ b/recipes/cpc1/e029_sheffield/transformer_cpc1.yaml
@@ -100,6 +100,7 @@ lm_weight: 0.00
 ctc_weight_decode: 0.40
 topk: 10
 n_ensembles: 6
+temperature: 1
 
 ############################## models ################################
 

--- a/recipes/cpc1/e029_sheffield/transformer_cpc1_ensemble_decoder.py
+++ b/recipes/cpc1/e029_sheffield/transformer_cpc1_ensemble_decoder.py
@@ -5,6 +5,8 @@ Authors
  * Peter Plantinga 2020
  * Mirco Ravanelli 2020
  * Sung-Lin Yeh 2020
+
+Modified by Zehai Tu for uncertainty estimation with ensemble
 """
 import speechbrain as sb
 import torch


### PR DESCRIPTION
Pass the n_ensembles parameter to S2STransformerBeamSearch, so that multiple ASR models can be used (used to be just the first ASR model).