### PR TITLE
Unittests for clarity/data/*.py; introduces tests/conftest.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 #      - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         types: [python]
@@ -41,7 +41,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.4.0
+    rev: 1.5.3
     hooks:
       - id: nbqa-black
       - id: nbqa-flake8
@@ -54,12 +54,12 @@ repos:
 #      - id: databooks-meta
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
 
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.982
     hooks:
       - id: mypy

--- a/clarity/data/HOA_tools_cec2.py
+++ b/clarity/data/HOA_tools_cec2.py
@@ -71,6 +71,8 @@ def centred_element(r: np.ndarray, i: int, j: int):
         Any: matrix element
     """
     offset = int((r.shape[0] - 1) / 2)
+    if i > r.shape[0] or j > r.shape[1]:
+        raise IndexError
     output = r[i + offset, j + offset]
     return output
 
@@ -446,8 +448,12 @@ def rotation_control_vector(
     Returns:
         array: mapped rotation control vector
     """
-    assert end_idx > start_idx
-    assert array_length > end_idx
+    # assert end_idx > start_idx
+    # assert array_length > end_idx
+    if start_idx > end_idx:
+        raise ValueError(f"start_idx ({start_idx}) > end_idx ({end_idx})")
+    if end_idx > array_length:
+        raise ValueError(f"array_length ({array_length}) > end_idx {end_idx}")
     x = np.arange(0, array_length)
     idx = smoothstep(x, x_min=start_idx, x_max=end_idx, N=smoothness)
     idx = np.array(np.floor(idx * (array_length - 1)), dtype=int)
@@ -474,7 +480,13 @@ def rotation_vector(
         np.array: _description_
     """
     turn_direction = -np.sign(start_angle - end_angle)
-    increment = (np.abs(start_angle - end_angle) / signal_length) * turn_direction
+    with np.errstate(divide="raise"):
+        try:
+            increment = (
+                np.abs(start_angle - end_angle) / signal_length
+            ) * turn_direction
+        except FloatingPointError:
+            raise
     theta = np.arange(start_angle, end_angle, increment)
     idx = rotation_control_vector(signal_length, start_idx, end_idx)
     return theta[idx]

--- a/clarity/data/utils.py
+++ b/clarity/data/utils.py
@@ -32,8 +32,11 @@ def better_ear_speechweighted_snr(target: np.ndarray, noise: np.ndarray) -> floa
     """
     if np.ndim(target) == 1:
         # analysis left ear and right ear for single channel target
-        left_snr = speechweighted_snr(target, noise[:, 0])
-        right_snr = speechweighted_snr(target, noise[:, 1])
+        try:
+            left_snr = speechweighted_snr(target, noise[:, 0])
+            right_snr = speechweighted_snr(target, noise[:, 1])
+        except IndexError:
+            raise
     else:
         # analysis left ear and right ear for two channel target
         left_snr = speechweighted_snr(target[:, 0], noise[:, 0])
@@ -43,20 +46,26 @@ def better_ear_speechweighted_snr(target: np.ndarray, noise: np.ndarray) -> floa
     return be_snr
 
 
-def speechweighted_snr(target, noise):
+def speechweighted_snr(target: np.ndarray, noise: np.ndarray) -> float:
     """Apply speech weighting filter to signals and get SNR.
 
     Args:
-        target (np.array):
-        noise ():
+        target (np.ndarray):
+        noise (np.ndarray):
 
     Returns:
+        (float):
+    Signal Noise Ratio
     """
-    target_filt = scipy.signal.convolve(
-        target, SPEECH_FILTER, mode="full", method="fft"
-    )
-    noise_filt = scipy.signal.convolve(noise, SPEECH_FILTER, mode="full", method="fft")
-
+    try:
+        target_filt = scipy.signal.convolve(
+            target, SPEECH_FILTER, mode="full", method="fft"
+        )
+        noise_filt = scipy.signal.convolve(
+            noise, SPEECH_FILTER, mode="full", method="fft"
+        )
+    except ValueError:
+        raise
     # rms of the target after speech weighted filter
     targ_rms = np.sqrt(np.mean(target_filt**2))
 
@@ -97,7 +106,10 @@ def pad(signal: np.ndarray, length: int) -> np.ndarray:
         np.array:
     """
     # FIXME : Consider encapsulating in a 'try: ... except: ...' should the assertion not be met.
-    assert length >= signal.shape[0]
+    try:
+        assert length >= signal.shape[0]
+    except AssertionError:
+        raise
     return np.pad(
         signal, ([(0, length - signal.shape[0])] + ([(0, 0)] * (len(signal.shape) - 1)))
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Fixtures for testing."""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+
+SEED = 564687
+rng = np.random.default_rng(SEED)
+
+
+@pytest.fixture
+def random_matrix() -> np.ndarray:
+    """Generate a random matrix for use in tests."""
+    return np.asarray(rng.random((100, 100)))

--- a/tests/data/test_HOA_tools_cec2.py
+++ b/tests/data/test_HOA_tools_cec2.py
@@ -1,0 +1,305 @@
+"""Tests for the data.HOA_tools_cec2 module."""
+import numpy as np
+import pytest
+
+from clarity.data.HOA_tools_cec2 import (  # HOARotator,; ambisonic_convolve,; binaural_mixdown,; compute_band_rotation,; compute_rotation_matrix,; dB_to_gain,; dot,; smoothstep,
+    P,
+    U,
+    V,
+    W,
+    centred_element,
+    compute_rms,
+    compute_UVW_coefficients,
+    equalise_rms_levels,
+    rotation_control_vector,
+    rotation_vector,
+)
+
+
+def test_compute_rotation_matrix() -> None:
+    """Test for compute_rotation_matrix() function."""
+    assert True
+
+
+@pytest.mark.parametrize(
+    "i, j, expected",
+    [
+        (1, 1, 0.8840922122960315),
+        (45, 54, 0.2378095805520779),
+        (18, 91, 0.39897595320190293),
+    ],
+)
+def test_centred_element(
+    random_matrix: np.ndarray, i: int, j: int, expected: float
+) -> None:
+    """Test for centered_element() function."""
+    assert centred_element(random_matrix, i, j) == expected
+
+
+def test_centred_element_index_error(random_matrix: np.ndarray) -> None:
+    """Test centered_element() raises an IndexError if centering is outside of matrix dimensions."""
+    with pytest.raises(IndexError):
+        centred_element(random_matrix, i=101, j=2)
+    with pytest.raises(IndexError):
+        centred_element(random_matrix, i=1, j=102)
+
+
+@pytest.mark.parametrize(
+    "i, a, b, el, expected",
+    [
+        (1, 1, 2, 2, -0.3475073926260553),
+        (1, 1, 2, -2, 0.6814353682034401),
+        (1, 1, 2, 2, -0.7185822065660934),
+    ],
+)
+def test_P(
+    i: int, a: int, b: int, el: int, random_matrix: np.ndarray, expected: float
+) -> None:
+    """Test for P() function."""
+    # FixMe : how long is the list of matrices that is passed in?
+    assert P(i, a, b, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+
+
+def test_P_index_error(random_matrix: np.ndarray) -> None:
+    """Test P() raises IndexError if invalid indices to r are provided."""
+    # FixMe : how long is the list of matrices that is passed in?
+    with pytest.raises(IndexError):
+        assert P(i=1, a=5, b=1, el=1, r=[random_matrix])
+    with pytest.raises(IndexError):
+        assert P(i=1, a=5, b=1, el=-1, r=[random_matrix])
+    with pytest.raises(IndexError):
+        assert P(i=1, a=5, b=4, el=3, r=[random_matrix])
+
+
+@pytest.mark.parametrize(
+    "m, n, el, expected",
+    [
+        (1, 2, 2, 0.8066335578037782),
+        (1, 2, -2, 0.647932971103906),
+        (1, 2, 2, 0.504340149676519),
+    ],
+)
+def test_U(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
+    """Test for XX function."""
+    assert U(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+
+
+@pytest.mark.parametrize(
+    "m, n, el, expected",
+    [
+        (0, 2, 2, -0.02607000059684761),
+        (1, 2, 2, -0.8041211269599031),
+        (1, 2, -2, 0.889239093568916),
+        (-1, 2, -2, 0.5668224726503112),
+    ],
+)
+def test_V(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
+    """Test for V() function."""
+    assert V(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+
+
+@pytest.mark.parametrize(
+    "m, n, el, expected",
+    [
+        (0, 2, 2, 0.0),
+        (1, 2, 2, -0.18322112315448064),
+        (-1, 2, 2, -0.3501066433176404),
+    ],
+)
+def test_W(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
+    """Test for W() function."""
+    assert W(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+
+
+@pytest.mark.parametrize(
+    "m, n, el, expected",
+    [
+        (0, 2, 2, (0.5773502691896257, -0.28867513459481287, -0.0)),
+        (1, 2, 2, (0.5, 0.3535533905932738, -0.0)),
+        (-1, 2, 3, (1.2649110640673518, 0.7745966692414834, -0.31622776601683794)),
+        # (-1, 2, 1, (-0.0, np.nan, -0.0)),  # FixMe : This is probably going to cause problems how to capture?
+    ],
+)
+def test_compute_UVW_coefficients(m: int, n: int, el: int, expected: float) -> None:
+    """Test for computer_UVW_coefficients() function."""
+    assert compute_UVW_coefficients(m, n, el) == expected
+
+
+def test_compute_UVW_coefficients_zero_division_error() -> None:
+    """Test computer_UVW_coefficients() raises ZeroDivisionError"""
+    with pytest.raises(ZeroDivisionError):
+        compute_UVW_coefficients(m=-1, n=2, el=-2)
+
+
+# FixMe : Not yet working, I don't understand how to get the `output` passed in correctly
+# @pytest.mark.parametrize(
+#     "el, output, expected",
+#     [
+#         (2, np.asarray([0, 0]), np.asarray([[1, 2], [3, 4]])),
+#     ],
+# )
+# def test_compute_band_rotation(el: int, output: np.ndarray, random_matrix: np.ndarray, expected: np.ndarray) -> None:
+#     """Test for compute_band_rotation() function."""
+#     np.testing.assert_array_equal(compute_band_rotation(el, [random_matrix, random_matrix], output), expected)
+
+
+# FixMe : Not working yet, results in a typing error???
+# @pytest.mark.parametrize(
+#     "A, B, expected",
+#     [
+#         (np.asarray([[1, 2], [3, 4]]), np.asarray([[4, 3], [2, 1]]), np.asarray([[1, 2], [3, 4]])),
+#         (np.asarray([[5, 6], [7, 8]]), np.asarray([[8, 7], [6, 5]]), np.asarray([[1, 2], [3, 4]])),
+#     ],
+# )
+# def test_dot(A: np.ndarray, B: np.ndarray, expected: np.ndarray) -> None:
+#     """Test for XX function."""
+#     np.testing.assert_array_equal(dot(A, B), expected)
+
+
+def test_HOARotator() -> None:
+    """Test for test_HOARotator class."""
+    assert True
+
+
+def test_binaural_mixdown() -> None:
+    """Test for binaural_mixdown() function."""
+    assert True
+
+
+def test_ambisonic_convolve() -> None:
+    """Test for ambisonic_convolve() function."""
+    assert True
+
+
+@pytest.mark.parametrize(
+    "array, axis, expected",
+    [
+        (
+            np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+            0,
+            [
+                np.sqrt(np.mean([1**2, 4**2, 7**2])),
+                np.sqrt(np.mean([2**2, 5**2, 8**2])),
+                np.sqrt(np.mean([3**2, 6**2, 9**2])),
+            ],
+        ),
+        (
+            np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+            1,
+            [
+                np.sqrt(np.mean([1**2, 2**2, 3**2])),
+                np.sqrt(np.mean([4**2, 5**2, 6**2])),
+                np.sqrt(np.mean([7**2, 8**2, 9**2])),
+            ],
+        ),
+    ],
+)
+def test_compute_rms(array: np.ndarray, axis: int, expected: float) -> None:
+    """Test for compute_rms() function along both axes."""
+    np.testing.assert_array_equal(compute_rms(input_signal=array, axis=axis), expected)
+
+
+def test_equalise_rms_levels(random_matrix: np.ndarray) -> None:
+    """Test for equalise_rms_levels() function."""
+    assert equalise_rms_levels(inputs=[random_matrix, random_matrix])
+
+
+def test_dB_to_gain() -> None:
+    """Test for XX function."""
+    assert True
+
+
+def test_smoothstep() -> None:
+    """Test for XX function."""
+    assert True
+
+
+@pytest.mark.parametrize(
+    "array_length, start_idx, end_idx, expected",
+    [
+        (10, 2, 8, np.asarray([0, 0, 0, 0, 2, 4, 6, 8, 9, 9])),  # start_idx > end_idx
+        (
+            10,
+            1,
+            5,
+            np.asarray([0, 0, 1, 4, 7, 9, 9, 9, 9, 9]),
+        ),  # end_idx > signal_length
+    ],
+)
+def test_rotation_control_vector(
+    array_length: int, start_idx: int, end_idx: int, expected: np.ndarray
+) -> None:
+    """Test for rotation_control_vector() function."""
+    np.testing.assert_array_equal(
+        rotation_control_vector(array_length, start_idx, end_idx), expected
+    )
+
+
+@pytest.mark.parametrize(
+    "array_length, start_idx, end_idx",
+    [
+        (100, 90, 80),  # start_idx > end_idx
+        (100, 20, 110),  # end_idx > signal_length
+    ],
+)
+def test_rotation_control_vector_value_error(
+    array_length: int, start_idx: int, end_idx: int
+) -> None:
+    """Test rotation_control_vector() raises ValueError if start_idx > end_idx or end_idx > array_length."""
+    with pytest.raises(ValueError):
+        rotation_control_vector(array_length, start_idx, end_idx)
+
+
+@pytest.mark.parametrize(
+    "start_angle, end_angle, signal_length, start_idx, end_idx, expected",
+    [
+        (
+            10,
+            20,
+            10,
+            2,
+            8,
+            np.asarray([10.0, 10.0, 10.0, 10.0, 12.0, 14.0, 16.0, 18.0, 19.0, 19.0]),
+        ),
+        (
+            -10,
+            20,
+            10,
+            2,
+            8,
+            np.asarray([-10.0, -10.0, -10.0, -10.0, -4.0, 2.0, 8.0, 14.0, 17.0, 17.0]),
+        ),
+        (
+            -10,
+            -20,
+            10,
+            2,
+            8,
+            np.asarray(
+                [-10.0, -10.0, -10.0, -10.0, -12.0, -14.0, -16.0, -18.0, -19.0, -19.0]
+            ),
+        ),
+    ],
+)
+def test_rotation_vector(
+    start_angle: float,
+    end_angle: float,
+    signal_length: int,
+    start_idx: int,
+    end_idx: int,
+    expected: np.ndarray,
+) -> None:
+    """Test for rotation_vector() function."""
+    np.testing.assert_array_equal(
+        rotation_vector(start_angle, end_angle, signal_length, start_idx, end_idx),
+        expected,
+    )
+    assert True
+
+
+def test_rotation_vector_floating_point_error() -> None:
+    """Test rotation_vector() raises FloatingPointError if signal_length is zero function."""
+    with pytest.raises(FloatingPointError):
+        rotation_vector(
+            start_angle=10, end_angle=20, signal_length=0, start_idx=2, end_idx=8
+        )

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -1,0 +1,145 @@
+"""Tests for the data.utils module."""
+from typing import List
+
+import numpy as np
+import pytest
+
+from clarity.data.utils import (
+    better_ear_speechweighted_snr,
+    pad,
+    speechweighted_snr,
+    sum_signals,
+)
+
+SEED = 864813
+rng = np.random.default_rng(SEED)
+
+
+@pytest.mark.parametrize(
+    "target, noise, expected",
+    [
+        (
+            np.asarray([1, 2, 3, 4]),
+            np.asarray([[4, 3, 2, 1], [4, 3, 2, 1]]),
+            1.5296464383117123,
+        ),
+        (
+            np.asarray(rng.random(20)),
+            np.asarray(rng.random((2, 10))),
+            37.079860336786695,
+        ),
+        (
+            np.asarray(rng.random((2, 10))),
+            np.asarray(rng.random((2, 10))),
+            1.3658122884632578,
+        ),
+        (
+            np.asarray(rng.random((100, 100))),
+            np.asarray(rng.random((100, 100))),
+            0.9781085375091217,
+        ),
+    ],
+)
+def test_better_ear_speechweighted_snr(
+    target: np.ndarray, noise: np.ndarray, expected: float
+) -> None:
+    """Test of better_ear_speechweighted_snr()."""
+    better_ear_signal_noise_ratio = better_ear_speechweighted_snr(target, noise)
+    assert isinstance(better_ear_signal_noise_ratio, float)
+    assert better_ear_signal_noise_ratio == expected
+
+
+def test_better_ear_speechweighted_snr_noise_wrong_shape_index_error() -> None:
+    """Test of better_ear_speechweighted_snr()."""
+    with pytest.raises(IndexError):
+        better_ear_speechweighted_snr(
+            target=np.asarray([1, 2, 3, 4]), noise=np.asarray([4, 3, 2, 1])
+        )
+
+
+@pytest.mark.parametrize(
+    "target, noise, expected",
+    [
+        (np.asarray([1, 2, 3, 4]), np.asarray([4, 3, 2, 1]), 1.0),
+        (
+            np.asarray([1.1, 2.2, 3.3, 4.4]),
+            np.asarray([11.1, 22.2, 33.3, 44.4]),
+            0.0990990990990991,
+        ),
+        (np.asarray(rng.random(20)), np.asarray(rng.random(20)), 1.0961240900775582),
+        (np.asarray(rng.random(200)), np.asarray(rng.random(200)), 0.9653767031879813),
+        (
+            np.asarray(rng.random(1000)),
+            np.asarray(rng.random(1000)),
+            1.0195987176010093,
+        ),
+    ],
+)
+def test_speechweighted_snr(target: np.array, noise: np.array, expected: float) -> None:
+    """Test of speechweighted_snr()."""
+    signal_noise_ratio = speechweighted_snr(target, noise)
+    assert isinstance(signal_noise_ratio, float)
+    assert signal_noise_ratio == expected
+
+
+def test_speechweighted_snr_unequal_arrays_value_error() -> None:
+    """Test of speechweighted_snr()."""
+    with pytest.raises(ValueError):
+        speechweighted_snr(
+            target=np.asarray([[1, 2], [3, 4]]), noise=np.asarray([3, 4, 1, 2])
+        )
+
+
+@pytest.mark.parametrize(
+    "signals, expected",
+    [
+        (
+            [
+                np.asarray([[1, 2], [3, 4], [5, 6], [7, 8]]),
+                np.asarray([[9, 10], [11, 12], [13, 14]]),
+                np.asarray([[15, 16], [17, 18]]),
+            ],
+            np.asarray([[25, 28], [31, 34], [18, 20], [7, 8]]),
+        ),
+        (
+            [
+                np.asarray([[1, 2], [3, 4]]),
+                np.asarray([[5, 6], [7, 8]]),
+                np.asarray([[9, 10], [11, 12]]),
+            ],
+            np.asarray([[15, 18], [21, 24]]),
+        ),
+    ],
+)
+def test_sum_signals(signals: List[int], expected: np.ndarray) -> None:
+    """Test of sum_signals()."""
+    summed_signals = sum_signals(signals)
+    np.testing.assert_array_equal(summed_signals, expected)
+
+
+@pytest.mark.parametrize(
+    "signal, length, expected",
+    [
+        (
+            np.asarray([[1, 2], [3, 4], [5, 6], [7, 8]]),
+            4,
+            np.asarray([[1, 2], [3, 4], [5, 6], [7, 8]]),
+        ),
+        (
+            np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+            4,
+            np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9], [0, 0, 0]]),
+        ),
+    ],
+)
+def test_pad(signal: np.ndarray, length: int, expected: np.ndarray) -> None:
+    """Test of pad()."""
+    padded_array = pad(signal, length)
+    assert isinstance(padded_array, np.ndarray)
+    np.testing.assert_array_equal(padded_array, expected)
+
+
+def test_pad_invalid_length_assertion_error() -> None:
+    """Test pad() raises an exception when length < signal.shape[0]."""
+    with pytest.raises(AssertionError):
+        pad(signal=np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), length=2)


### PR DESCRIPTION
Trying again as #88 was messy and confusing. Branched freshly from `main` and pulled over `tests/data/test_{utils,HOA_tools_cec2}.py` as well as `tests/conftest.py`, then added the `try: ... except: ...` statements I'd introduced to `clarity/data/utils.py` and `clarity/data/HOA_tools_cec2.py`.

All but two tests pass locally, the two that fail appear to be due to Torch trying to use my CPU and GPU (as mentioned in #97).

I've also made sure the `.pre-commit-config.yaml` uses up-to-date versions of each virtual environment (see [comment](https://github.com/claritychallenge/clarity/issues/97#issuecomment-1302254717)).