### PR TITLE
Fix cuda issue in test_enhancers & test_mc_conv_tasnet

### DIFF
--- a/tests/regression/test_enhancers.py
+++ b/tests/regression/test_enhancers.py
@@ -28,9 +28,8 @@ def test_dsp_filter(regtest):
     torch.manual_seed(0)
     signal = torch.rand(10, dtype=torch.float)
     signal = torch.reshape(signal, (1, 1, -1))
-    signal.to(amfir.device)
-    output = amfir(signal)
-    output = np.round(output.detach().numpy(), 4)
+    output = amfir(signal.to(amfir.device))
+    output = np.round(output.detach().cpu().numpy(), 4)
     regtest.write(f"signal output: \n{output}\n")
 
 

--- a/tests/regression/test_mc_conv_tasnet.py
+++ b/tests/regression/test_mc_conv_tasnet.py
@@ -84,10 +84,11 @@ def test_convtasnet(regtest):
                 den_model.eval()
 
                 noisy = torch.reshape(noisy, (1, 6, -1))
-                noisy = noisy.to(device)
+                noisy = noisy.to(device).cpu()
                 if cfg.test_dataset["downsample_factor"] != 1:
                     proc = down_sample(noisy)
                 enhanced = (den_model(proc)).squeeze(1)
+                enhanced = enhanced.cpu()
                 if cfg.test_dataset["downsample_factor"] != 1:
                     enhanced = up_sample(enhanced)
                 enhanced = torch.clamp(enhanced, -1, 1)


### PR DESCRIPTION
In test_enhancers.py: move signal to amfir.device properly, and add cpu() before converting to numpy
In test_mc_conv_tasnet.py: downsample functions operates on cpu