### PR TITLE
Nomenclature PEP8 compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 #      - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         types: [python]
@@ -41,7 +41,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.4.0
+    rev: 1.5.3
     hooks:
       - id: nbqa-black
       - id: nbqa-flake8
@@ -54,12 +54,12 @@ repos:
 #      - id: databooks-meta
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
 
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.982
     hooks:
       - id: mypy

--- a/.pylintrc
+++ b/.pylintrc
@@ -78,8 +78,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=C0103,
-        R0801,
+disable=R0801,
+        #C0103,
         raw-checker-failed,
         bad-inline-option,
         locally-disabled,
@@ -574,4 +574,3 @@ min-public-methods=2
 # "BaseException, Exception".
 overgeneral-exceptions=BaseException,
                        Exception
-

--- a/clarity/evaluator/mbstoi/mbstoi.py
+++ b/clarity/evaluator/mbstoi/mbstoi.py
@@ -48,31 +48,21 @@ def mbstoi(
 ) -> float:
     """Implementation of the Modified Binaural Short-Time Objective Intelligibility (mbstoi) measure.
 
-    Parameters
-    ----------
-    left_ear_clean : np.ndarray
-        Clean speech signal from left ear.
-    right_ear_clean : np.ndarray
-        Clean speech signal from right ear.
-    left_ear_noisy : np.ndarray
-        Noisy/processed speech signal from left ear.
-    right_ear_noisy : np.ndarray
-        Noisy/processed speech signal from right ear.
-    fs_signal : int
-        Frequency sample rate of signal.
-    gridcoarseness : int
-        Grid coarseness as denominator of ntaus and ngammas (default: 1).
+    Args:
+        left_ear_clean (np.ndarray): Clean speech signal from left ear.
+        right_ear_clean (np.ndarray): Clean speech signal from right ear.
+        left_ear_noisy (np.ndarray) : Noisy/processed speech signal from left ear.
+        right_ear_noisy (np.ndarray) : Noisy/processed speech signal from right ear.
+        fs_signal (int) : Frequency sample rate of signal.
+        gridcoarseness (int) : Grid coarseness as denominator of ntaus and ngammas (default: 1).
 
-    Returns
-    -------
-    float
-        mbtsoi index d.
+    Returns:
+        float : mbtsoi index d.
 
-    Notes
-    -----
-    All title, copyrights and pending patents pertaining to mbtsoi[1]_ in and to the original Matlab software are owned
-    by oticon a/s and/or Aalborg University. please see details at `http://ah-andersen.net/code/
-    <http://ah-andersen.net/code/>`_
+    Notes:
+        All title, copyrights and pending patents pertaining to mbtsoi[1]_ in and to the original Matlab software are
+        owned by oticon a/s and/or Aalborg University. please see details at
+        `http://ah-andersen.net/code/<http://ah-andersen.net/code/>`
 
 
     .. [1] A. H. Andersen, J. M. de Haan, Z.-H. Tan, and J. Jensen (2018) Refinement and validation of the binaural

--- a/clarity/evaluator/mbstoi/mbstoi.py
+++ b/clarity/evaluator/mbstoi/mbstoi.py
@@ -4,7 +4,7 @@ import logging
 import math
 
 import numpy as np
-import yaml
+import yaml  # type: ignore
 from scipy.signal import resample
 
 from clarity.evaluator.mbstoi.mbstoi_utils import (

--- a/clarity/evaluator/mbstoi/mbstoi.py
+++ b/clarity/evaluator/mbstoi/mbstoi.py
@@ -1,153 +1,218 @@
+"""Modified Binaural Short-Time Objective Intelligibility (MBSTOI) Measure"""
+import importlib.resources as pkg_resources
 import logging
 import math
 
 import numpy as np
+import yaml
 from scipy.signal import resample
 
 from clarity.evaluator.mbstoi.mbstoi_utils import (
-    ec,
+    equalisation_cancellation,
     remove_silent_frames,
     stft,
     thirdoct,
 )
 
+# pylint: disable=too-many-locals
 
-def mbstoi(xl, xr, yl, yr, fs_signal, gridcoarseness=1):
-    """A Python implementation of the Modified Binaural Short-Time
-    Objective Intelligibility (MBSTOI) measure as described in:
-    A. H. Andersen, J. M. de Haan, Z.-H. Tan, and J. Jensen, “Refinement
-    and validation of the binaural short time objective intelligibility
-    measure for spatially diverse conditions,” Speech Communication,
-    vol. 102, pp. 1-13, Sep. 2018. A. H. Andersen, 10/12-2018
 
-    All title, copyrights and pending patents in and to the original MATLAB
-    Software are owned by Oticon A/S and/or Aalborg University. Please see
-    details at http://ah-andersen.net/code/
+# basic stoi parameters from file
+params_file = pkg_resources.open_text(__package__, "parameters.yaml")
+basic_stoi_parameters = yaml.safe_load(params_file.read())
 
-    Args:
-        xl (ndarray): clean speech signal from left ear
-        xr (ndarray): clean speech signal from right ear.
-        yl (ndarray): noisy/processed speech signal from left ear.
-        yr (ndarray): noisy/processed speech signal from right ear.
-        gridcoarseness (integer): grid coarseness as denominator of ntaus and ngammas (default: 1)
+
+def mbstoi(
+    left_ear_clean: np.ndarray,
+    right_ear_clean: np.ndarray,
+    left_ear_noisy: np.ndarray,
+    right_ear_noisy: np.ndarray,
+    fs_signal,
+    gridcoarseness: int = 1,
+    sample_rate: int = 10000,
+    n_frame: int = 256,
+    fft_size_in_samples: int = 512,
+    n_third_octave_bands: int = 15,
+    centre_freq_first_third_octave_hz: int = 150,
+    n_frames: int = 30,
+    dyn_range: int = 40,
+    tau_min: float = -0.001,
+    tau_max: float = 0.001,
+    gamma_min: int = -20,
+    gamma_max: int = 20,
+    sigma_delta_0: float = 65e-6,
+    sigma_epsilon_0: float = 1.5,
+    alpha_0_db: int = 13,
+    tau_0: float = 1.6e-3,
+    level_shift_deviation: float = 1.6,
+) -> float:
+    """Implementation of the Modified Binaural Short-Time Objective Intelligibility (mbstoi) measure.
+
+    Parameters
+    ----------
+    left_ear_clean : np.ndarray
+        Clean speech signal from left ear.
+    right_ear_clean : np.ndarray
+        Clean speech signal from right ear.
+    left_ear_noisy : np.ndarray
+        Noisy/processed speech signal from left ear.
+    right_ear_noisy : np.ndarray
+        Noisy/processed speech signal from right ear.
+    fs_signal : int
+        Frequency sample rate of signal.
+    gridcoarseness : int
+        Grid coarseness as denominator of ntaus and ngammas (default: 1).
 
     Returns
-        float: MBSTOI index d
+    -------
+    float
+        mbtsoi index d.
 
+    Notes
+    -----
+    All title, copyrights and pending patents pertaining to mbtsoi[1]_ in and to the original Matlab software are owned
+    by oticon a/s and/or Aalborg University. please see details at `http://ah-andersen.net/code/
+    <http://ah-andersen.net/code/>`_
+
+
+    .. [1] A. H. Andersen, J. M. de Haan, Z.-H. Tan, and J. Jensen (2018) Refinement and validation of the binaural
+    short time objective intelligibility measure for spatially diverse conditions. Speech Communication vol. 102,
+    pp. 1-13 `doi:10.1016/j.specom.2018.06.001 <https://doi.org/10.1016/j.specom.2018.06.001>`_
     """
 
-    # Basic STOI parameters
-    fs = 10000  # Sample rate of proposed intelligibility measure in Hz
-    N_frame = 256  # Window support in samples
-    K = 512  # FFT size in samples
-    J = 15  # Number of one-third octave bands
-    mn = 150  # Centre frequency of first 1/3 octave band in Hz
-    N = 30  # Number of frames for intermediate intelligibility measure (length analysis window)
-    dyn_range = 40  # Speech dynamic range in dB
+    n_taus = math.ceil(100 / gridcoarseness)  # number of tau values to try out
+    n_gammas = math.ceil(40 / gridcoarseness)  # number of gamma values to try out
 
-    # Values to define EC grid
-    tau_min = -0.001  # Minimum interaural delay compensation in seconds. B: -0.01.
-    tau_max = 0.001  # Maximum interaural delay compensation in seconds. B: 0.01.
-    ntaus = math.ceil(100 / gridcoarseness)  # Number of tau values to try out
-    gamma_min = -20  # Minimum interaural level compensation in dB
-    gamma_max = 20  # Maximum interaural level compensation in dB
-    ngammas = math.ceil(40 / gridcoarseness)  # Number of gamma values to try out
-
-    # Constants for jitter
-    # ITD compensation standard deviation in seconds. Equation 6 Andersen et al. 2018 Refinement
-    sigma_delta_0 = 65e-6
-    # ILD compensation standard deviation.  Equation 5 Andersen et al. 2018
-    sigma_epsilon_0 = 1.5
-    # Constant for level shift deviation in dB. Equation 5 Andersen et al. 2018
-    alpha_0_db = 13
-    # Constant for time shift deviation in seconds. Equation 6 Andersen et al. 2018
-    tau_0 = 1.6e-3
-    # Constant for level shift deviation. Power for calculation of sigma delta gamma
-    # in equation 5 Andersen et al. 2018.
-    p = 1.6
-
-    # Prepare signals, ensuring that inputs are column vectors
-    xl = xl.flatten()
-    xr = xr.flatten()
-    yl = yl.flatten()
-    yr = yr.flatten()
+    # prepare signals, ensuring that inputs are column vectors
+    left_ear_clean = left_ear_clean.flatten()
+    right_ear_clean = right_ear_clean.flatten()
+    left_ear_noisy = left_ear_noisy.flatten()
+    right_ear_noisy = right_ear_noisy.flatten()
 
     # Resample signals to 10 kHz
-    if fs_signal != fs:
+    if fs_signal != sample_rate:
 
-        logging.debug("Resampling signals with sr=%s for MBSTOI calculation.", fs)
+        logging.debug(
+            "Resampling signals with sr=%s for MBSTOI calculation.", sample_rate
+        )
         # Assumes fs_signal is 44.1 kHz
-        el = len(xl)
-        xl = resample(xl, int(el * (fs / fs_signal) + 1))
-        xr = resample(xr, int(el * (fs / fs_signal) + 1))
-        yl = resample(yl, int(el * (fs / fs_signal) + 1))
-        yr = resample(yr, int(el * (fs / fs_signal) + 1))
+        length_left_ear_clean = len(left_ear_clean)
+        left_ear_clean = resample(
+            left_ear_clean, int(length_left_ear_clean * (sample_rate / fs_signal) + 1)
+        )
+        right_ear_clean = resample(
+            right_ear_clean, int(length_left_ear_clean * (sample_rate / fs_signal) + 1)
+        )
+        left_ear_noisy = resample(
+            left_ear_noisy, int(length_left_ear_clean * (sample_rate / fs_signal) + 1)
+        )
+        right_ear_noisy = resample(
+            right_ear_noisy, int(length_left_ear_clean * (sample_rate / fs_signal) + 1)
+        )
 
     # Remove silent frames
-    [xl, xr, yl, yr] = remove_silent_frames(
-        xl, xr, yl, yr, dyn_range, N_frame, N_frame / 2
+    (
+        left_ear_clean,
+        right_ear_clean,
+        left_ear_noisy,
+        right_ear_noisy,
+    ) = remove_silent_frames(
+        left_ear_clean,
+        right_ear_clean,
+        left_ear_noisy,
+        right_ear_noisy,
+        dyn_range,
+        n_frame,
+        n_frame / 2,
     )
 
     # Handle case when signals are zeros
     if (
-        abs(np.log10(np.linalg.norm(xl) / np.linalg.norm(yl))) > 5.0
-        or abs(np.log10(np.linalg.norm(xr) / np.linalg.norm(yr))) > 5.0
+        abs(np.log10(np.linalg.norm(left_ear_clean) / np.linalg.norm(left_ear_noisy)))
+        > 5.0
+        or abs(
+            np.log10(np.linalg.norm(right_ear_clean) / np.linalg.norm(right_ear_noisy))
+        )
+        > 5.0
     ):
         sii = 0
 
     # STDFT and filtering
     # Get 1/3 octave band matrix
-    [H, cf, fids, _freq_low, _freq_high] = thirdoct(
-        fs, K, J, mn
+    [
+        octave_band_matrix,
+        centre_frequencies,
+        frequency_band_edges_indices,
+        _freq_low,
+        _freq_high,
+    ] = thirdoct(
+        sample_rate,
+        fft_size_in_samples,
+        n_third_octave_bands,
+        centre_freq_first_third_octave_hz,
     )  # (fs, nfft, num_bands, min_freq)
-    cf = 2 * math.pi * cf  # This is now the angular frequency in radians per sec
+    centre_frequencies = (
+        2 * math.pi * centre_frequencies
+    )  # This is now the angular frequency in radians per sec
 
     # Apply short time DFT to signals and transpose
-    xl_hat = stft(xl, N_frame, K).transpose()
-    xr_hat = stft(xr, N_frame, K).transpose()
-    yl_hat = stft(yl, N_frame, K).transpose()
-    yr_hat = stft(yr, N_frame, K).transpose()
+    left_ear_clean_hat = stft(left_ear_clean, n_frame, fft_size_in_samples).transpose()
+    right_ear_clean_hat = stft(
+        right_ear_clean, n_frame, fft_size_in_samples
+    ).transpose()
+    left_ear_noisy_hat = stft(left_ear_noisy, n_frame, fft_size_in_samples).transpose()
+    right_ear_noisy_hat = stft(
+        right_ear_noisy, n_frame, fft_size_in_samples
+    ).transpose()
 
     # Take single sided spectrum of signals
-    idx = int(K / 2 + 1)
-    xl_hat = xl_hat[0:idx, :]
-    xr_hat = xr_hat[0:idx, :]
-    yl_hat = yl_hat[0:idx, :]
-    yr_hat = yr_hat[0:idx, :]
+    idx = int(fft_size_in_samples / 2 + 1)
+    left_ear_clean_hat = left_ear_clean_hat[0:idx, :]
+    right_ear_clean_hat = right_ear_clean_hat[0:idx, :]
+    left_ear_noisy_hat = left_ear_noisy_hat[0:idx, :]
+    right_ear_noisy_hat = right_ear_noisy_hat[0:idx, :]
 
     # Compute intermediate correlation via EC search
     logging.info("Starting EC evaluation")
     # Here intermeduiate correlation coefficients are evaluated for a discrete set of
     # gamma and tau values (a "grid") and the highest value is chosen.
-    d = np.zeros((J, np.shape(xl_hat)[1] - N + 1))
-    p_ec_max = np.zeros((J, np.shape(xl_hat)[1] - N + 1))
+    intermediate_intelligibility_measure_grid = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1] - n_frames + 1)
+    )
+    p_ec_max = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1] - n_frames + 1)
+    )
 
     # Interaural compensation time and level values
-    taus = np.linspace(tau_min, tau_max, ntaus)
-    gammas = np.linspace(gamma_min, gamma_max, ngammas)
+    taus = np.linspace(tau_min, tau_max, n_taus)
+    gammas = np.linspace(gamma_min, gamma_max, n_gammas)
 
     # Jitter incorporated below - Equations 5 and 6 in Andersen et al. 2018
     sigma_epsilon = (
-        np.sqrt(2) * sigma_epsilon_0 * (1 + (abs(gammas) / alpha_0_db) ** p) / 20
+        np.sqrt(2)
+        * sigma_epsilon_0
+        * (1 + (abs(gammas) / alpha_0_db) ** level_shift_deviation)
+        / 20
     )
     gammas = gammas / 20
+
     sigma_delta = np.sqrt(2) * sigma_delta_0 * (1 + (abs(taus) / tau_0))
 
-    logging.info("Processing EC stage")
-    d, p_ec_max = ec(
-        xl_hat,
-        xr_hat,
-        yl_hat,
-        yr_hat,
-        J,
-        N,
-        fids,
-        cf.flatten(),
+    logging.info("Processing Equalisation Cancellation stage")
+    updated_intermediate_intelligibility_measure, p_ec_max = equalisation_cancellation(
+        left_ear_clean_hat,
+        right_ear_clean_hat,
+        left_ear_noisy_hat,
+        right_ear_noisy_hat,
+        n_third_octave_bands,
+        n_frames,
+        frequency_band_edges_indices,
+        centre_frequencies.flatten(),
         taus,
-        ntaus,
+        n_taus,
         gammas,
-        ngammas,
-        d,
+        n_gammas,
+        intermediate_intelligibility_measure_grid,
         p_ec_max,
         sigma_epsilon,
         sigma_delta,
@@ -156,54 +221,92 @@ def mbstoi(xl, xr, yl, yr, fs_signal, gridcoarseness=1):
     # Compute the better ear STOI
     logging.info("Computing better ear intermediate correlation coefficients")
     # Arrays for the 1/3 octave envelope
-    Xl = np.zeros((J, np.shape(xl_hat)[1]))
-    Xr = np.zeros((J, np.shape(xl_hat)[1]))
-    Yl = np.zeros((J, np.shape(xl_hat)[1]))
-    Yr = np.zeros((J, np.shape(xl_hat)[1]))
+    left_ear_clean_third_octave_band = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1])
+    )
+    right_ear_clean_third_octave_band = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1])
+    )
+    left_ear_noisy_third_octave_band = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1])
+    )
+    right_ear_noisy_third_octave_band = np.zeros(
+        (n_third_octave_bands, np.shape(left_ear_clean_hat)[1])
+    )
 
     # Apply 1/3 octave bands as described in Eq.(1) of the STOI article
-    for k in range(np.shape(xl_hat)[1]):
-        Xl[:, k] = np.dot(H, abs(xl_hat[:, k]) ** 2)
-        Xr[:, k] = np.dot(H, abs(xr_hat[:, k]) ** 2)
-        Yl[:, k] = np.dot(H, abs(yl_hat[:, k]) ** 2)
-        Yr[:, k] = np.dot(H, abs(yr_hat[:, k]) ** 2)
+    for k in range(np.shape(left_ear_clean_hat)[1]):
+        left_ear_clean_third_octave_band[:, k] = np.dot(
+            octave_band_matrix, abs(left_ear_clean_hat[:, k]) ** 2
+        )
+        right_ear_clean_third_octave_band[:, k] = np.dot(
+            octave_band_matrix, abs(right_ear_clean_hat[:, k]) ** 2
+        )
+        left_ear_noisy_third_octave_band[:, k] = np.dot(
+            octave_band_matrix, abs(left_ear_noisy_hat[:, k]) ** 2
+        )
+        right_ear_noisy_third_octave_band[:, k] = np.dot(
+            octave_band_matrix, abs(right_ear_noisy_hat[:, k]) ** 2
+        )
 
     # Arrays for better-ear correlations
-    dl_interm = np.zeros((J, len(range(N, len(xl_hat[1]) + 1))))
-    dr_interm = np.zeros((J, len(range(N, len(xl_hat[1]) + 1))))
-    pl = np.zeros((J, len(range(N, len(xl_hat[1]) + 1))))
-    pr = np.zeros((J, len(range(N, len(xl_hat[1]) + 1))))
+    dl_interm = np.zeros(
+        (n_third_octave_bands, len(range(n_frames, len(left_ear_clean_hat[1]) + 1)))
+    )
+    dr_interm = np.zeros(
+        (n_third_octave_bands, len(range(n_frames, len(left_ear_clean_hat[1]) + 1)))
+    )
+    left_improved = np.zeros(
+        (n_third_octave_bands, len(range(n_frames, len(left_ear_clean_hat[1]) + 1)))
+    )
+    right_improved = np.zeros(
+        (n_third_octave_bands, len(range(n_frames, len(left_ear_clean_hat[1]) + 1)))
+    )
 
     # Compute temporary better-ear correlations
-    for m in range(N, np.shape(xl_hat)[1]):
-        Xl_seg = Xl[:, (m - N) : m]
-        Xr_seg = Xr[:, (m - N) : m]
-        Yl_seg = Yl[:, (m - N) : m]
-        Yr_seg = Yr[:, (m - N) : m]
+    for m in range(
+        n_frames, np.shape(left_ear_clean_hat)[1]
+    ):  # pylint: disable=invalid-name
+        left_ear_clean_seg = left_ear_clean_third_octave_band[:, (m - n_frames) : m]
+        right_ear_clean_seg = right_ear_clean_third_octave_band[:, (m - n_frames) : m]
+        left_ear_noisy_seg = left_ear_noisy_third_octave_band[:, (m - n_frames) : m]
+        right_ear_noisy_seg = right_ear_noisy_third_octave_band[:, (m - n_frames) : m]
 
-        for n in range(J):
-            xln = Xl_seg[n, :] - np.sum(Xl_seg[n, :]) / N
-            xrn = Xr_seg[n, :] - np.sum(Xr_seg[n, :]) / N
-            yln = Yl_seg[n, :] - np.sum(Yl_seg[n, :]) / N
-            yrn = Yr_seg[n, :] - np.sum(Yr_seg[n, :]) / N
-            pl[n, m - N] = np.sum(xln * xln) / np.sum(yln * yln)
-            pr[n, m - N] = np.sum(xrn * xrn) / np.sum(yrn * yrn)
-            dl_interm[n, m - N] = np.sum(xln * yln) / (
-                np.linalg.norm(xln) * np.linalg.norm(yln)
+        for n in range(n_third_octave_bands):  # pylint: disable=invalid-name
+            left_ear_clean_n = (
+                left_ear_clean_seg[n, :] - np.sum(left_ear_clean_seg[n, :]) / n_frames
             )
-            dr_interm[n, m - N] = np.sum(xrn * yrn) / (
-                np.linalg.norm(xrn) * np.linalg.norm(yrn)
+            right_ear_clean_n = (
+                right_ear_clean_seg[n, :] - np.sum(right_ear_clean_seg[n, :]) / n_frames
             )
+            left_ear_noisy_n = (
+                left_ear_noisy_seg[n, :] - np.sum(left_ear_noisy_seg[n, :]) / n_frames
+            )
+            right_ear_noisy_n = (
+                right_ear_noisy_seg[n, :] - np.sum(right_ear_noisy_seg[n, :]) / n_frames
+            )
+            left_improved[n, m - n_frames] = np.sum(
+                left_ear_clean_n * left_ear_clean_n
+            ) / np.sum(left_ear_noisy_n * left_ear_noisy_n)
+            right_improved[n, m - n_frames] = np.sum(
+                right_ear_clean_n * right_ear_clean_n
+            ) / np.sum(right_ear_noisy_n * right_ear_noisy_n)
+            dl_interm[n, m - n_frames] = np.sum(left_ear_clean_n * left_ear_noisy_n) / (
+                np.linalg.norm(left_ear_clean_n) * np.linalg.norm(left_ear_noisy_n)
+            )
+            dr_interm[n, m - n_frames] = np.sum(
+                right_ear_clean_n * right_ear_noisy_n
+            ) / (np.linalg.norm(right_ear_clean_n) * np.linalg.norm(right_ear_noisy_n))
 
     # Get the better ear intermediate coefficients
     idx = np.isfinite(dl_interm)
     dl_interm[~idx] = 0
     idx = np.isfinite(dr_interm)
     dr_interm[~idx] = 0
-    p_be_max = np.maximum(pl, pr)
+    p_be_max = np.maximum(left_improved, right_improved)
     dbe_interm = np.zeros((np.shape(dl_interm)))
 
-    idx = pl > pr
+    idx = left_improved > right_improved
     dbe_interm[idx] = dl_interm[idx]
     dbe_interm[~idx] = dr_interm[~idx]
 
@@ -211,8 +314,8 @@ def mbstoi(xl, xr, yl, yr, fs_signal, gridcoarseness=1):
     # Whenever a single ear provides a higher correlation than the corresponding EC
     # processed alternative,the better-ear correlation is used.
     idx = p_be_max > p_ec_max
-    d[idx] = dbe_interm[idx]
-    sii = np.mean(d)
+    updated_intermediate_intelligibility_measure[idx] = dbe_interm[idx]
+    sii = np.mean(updated_intermediate_intelligibility_measure)
 
     logging.info("MBSTOI processing complete")
 

--- a/clarity/evaluator/mbstoi/mbstoi_utils.py
+++ b/clarity/evaluator/mbstoi/mbstoi_utils.py
@@ -29,50 +29,34 @@ def equalisation_cancellation(
 
     The EC loop evaluates one huge equation in every iteration (see referenced notes for details). The left and right
     ear signals are level adjusted by gamma (in dB) and time shifted by tau relative to one-another and are thereafter
-    subtracted. The processed signals are treated similarly. To obtain performance similar to that of humans,the EC stage adds
-    jitter. We are searching for the level and time adjustments that maximise the intermediate correlation coefficients
-    d. Could add location of source and interferer to this to reduce search space.
+    subtracted. The processed signals are treated similarly. To obtain performance similar to that of humans,the EC
+    stage adds jitter. We are searching for the level and time adjustments that maximise the intermediate correlation
+    coefficients d. Could add location of source and interferer to this to reduce search space.
 
-    Parameters
-    ----------
-    left_ear_clean_hat : np.ndarray
-        Noisy/processed left eat short-time DFT coefficients (single-sided) per frequency bin and frame.
-    right_ear_clean_hat : np.ndarray
-        Noisy/processed left eat short-time DFT coefficients (single-sided) per frequency bin and frame.
-    left_ear_noisy_hat : np.ndarray
-        Noisy/processed right eat short-time DFT coefficients (single-sided) per frequency bin and frame.
-    right_ear_noisy_hat : np.ndarray
-        Noisy/processed right eat short-time DFT coefficients (single-sided) per frequency bin and frame.
-    n_third_octave_bands: int
-        Number of one-third octave bands.
-    n_frames : int
-        Number of frames for intermediate intelligibility measure.
-    fids : np.ndarray
-        Indices of frequency band edges.
-    cf : np.ndarray
-        Centre frequencies.
-    taus : np.ndarray
-        Interaural delay (tau) values.
-    n_taus : int
-        Number of tau values.
-    gammas : np.ndarray
-        Interaural level difference (gamma) values.
-    ngammas : int
-        Number of gamma values.
-    intermediate_intelligibility_measure_grid : np.ndarray
-        Grid for intermediate intelligibility measure.
-    p_ec_max : np.ndarray
-        Empty grid for maximum values.
-    sigma_epsilon : np.ndarray
-        Jitter for gammas.
-    sigma_delta : np.ndarray
-        Jitter for taus.
+    Args:
+        left_ear_clean_hat (np.ndarray) : Clean left ear short-time DFT coefficients (single-sided) per frequency
+    bin and frame.
+        right_ear_clean_hat (np.ndarray) : Clean right ear short-time DFT coefficients (single-sided) per frequency bin and frame.
+        left_ear_noisy_hat (np.ndarray) : Noisy/processed left ear short-time DFT coefficients (single-sided) per
+    frequency bin and frame.
+        right_ear_noisy_hat (np.ndarray) : Noisy/processed right eat short-time DFT coefficients (single-sided) per
+    frequency bin and frame.
+    n_third_octave_bands (int) : Number of one-third octave bands.
+    n_frames (int) : Number of frames for intermediate intelligibility measure.
+    fids (np.ndarray) : Indices of frequency band edges.
+    cf (np.ndarray) : Centre frequencies.
+    taus (np.ndarray) : Interaural delay (tau) values.
+    n_taus (int) : Number of tau values.
+    gammas (np.ndarray) : Interaural level difference (gamma) values.
+    ngammas (int) : Number of gamma values.
+    intermediate_intelligibility_measure_grid (np.ndarray) : Grid for intermediate intelligibility measure.
+    p_ec_max (np.ndarray) : Empty grid for maximum values.
+    sigma_epsilon (np.ndarray) : Jitter for gammas.
+    sigma_delta (np.ndarray) : Jitter for taus.
 
-    Returns
-    -------
-    Tuple(np.ndarray, np.ndarray)
-        Tuple of d a np.ndarray of updated grid for intermediate intelligibility measure and the np.ndarray grid
-    containing maximum values.
+    Returns:
+        intermediate_intelligibility_measure_grid (np.ndarray) : updated grid for intermediate intelligibility measure
+        p_ec_max (np.ndarray) : grid containing maximum values.
     """
     taus = np.expand_dims(taus, axis=0)
     sigma_delta = np.expand_dims(sigma_delta, axis=0)
@@ -240,23 +224,15 @@ def firstpartfunc(
     # FixMe : Complete Docstring
     """Need a description
 
-    Parameters
-    ----------
-    L1: ???
-        ???
-    L2: ???
-        ???
-    R1: ???
-        ???
-    R2: ???
-        ???
-    n_taus: ???
-        ???
-    gammas: ???
-        ???
+    Args:
+        L1 (???) : ???
+        L2 (???) : ???
+        R1 (???) : ???
+        R2 (???) : ???
+        n_taus (???) : ???
+        gammas (???) : ???
 
-    Returns
-    -------
+    Returns:
     """
     result = (
         np.ones((n_taus, 1))
@@ -279,25 +255,16 @@ def secondpartfunc(
     # FixMe : Complete Docstring
     """Need a description
 
-    Parameters
-    ----------
-    L1: ???
-        ???
-    L2: ???
-        ???
-    rho1: ???
-        ???
-    rho2: ???
-        ???
-    tauexp: ???
-        ???
-    epsdelexp: ???
-        ???
-    gammas: ???
-        ???
+    Args:
+        L1 (???) : ???
+        L2 (???) : ???
+        rho1 (???) : ???
+        rho2 (???) : ???
+        tauexp (???) : ???
+        epsdelexp (???) : ???
+        gammas (???) : ???
 
-    Returns
-    -------
+    Returns:
     """
     result = (
         2
@@ -317,25 +284,16 @@ def thirdpartfunc(R1, R2, rho1, rho2, tauexp, epsdelexp, gammas: np.ndarray):
     # FixMe : Complete docstring
     """Need a description
 
-    Parameters
-    ----------
-    R1: ???
-        ???
-    R2: ???
-        ???
-    rho1: ???
-        ???
-    rho2: ???
-        ???
-    tauexp: ???
-        ???
-    epsdelexp: ???
-        ???
-    gammas: ???
-        ???
+    Args:
+        R1 (???) : ???
+        R2 (???) : ???
+        rho1 (???) : ???
+        rho2 (???) : ???
+        tauexp (???) : ???
+        epsdelexp (???) : ???
+        gammas (???) : ???
 
-    Returns
-    -------
+    Returns:
     """
     result = (
         2
@@ -353,21 +311,14 @@ def fourthpartfunc(rho1, rho2, tauexp2, n_gammas, deltexp):
     # FixMe : Complete docstring
     """Need a description
 
-    Parameters
-    ----------
-    rho1: ???
-        ???
-    rho2: ???
-        ???
-    tauexp2: ???
-        ???
-    n_gammas: ???
-        ???
-    deltexp: ???
-        ???
+    Args:
+    rho1 (???) : ???
+    rho2 (???) : ???
+    tauexp2 (???) : ???
+    n_gammas (???) : ???
+    deltexp (???) : ???
 
     Returns
-    -------
     """
     result = (
         2
@@ -387,19 +338,13 @@ def fourthpartfunc(rho1, rho2, tauexp2, n_gammas, deltexp):
 def stft(signal: np.ndarray, win_size: int, fft_size: int) -> np.ndarray:
     """Short-time Fourier transform based on MBSTOI Matlab code.
 
-    Parameters
-    ----------
-    signal: np.ndarray
-        Input signal
-    win_size: int
-        The size of the window and the signal frames.
-    fft_size: int
-        The size of the fft in samples (zero-padding or not).
+    Args:
+        signal (np.ndarray) : Input signal
+        win_size (int) : The size of the window and the signal frames.
+        fft_size (int) : The size of the fft in samples (zero-padding or not).
 
-    Returns
-    -------
-    np.ndarray:
-        The short-time Fourier transform of signal.
+    Returns:
+        stft_out (np.ndarray) : The short-time Fourier transform of signal.
     """
     hop = int(win_size / 2)
     frames = list(range(0, len(signal) - win_size, hop))
@@ -422,9 +367,9 @@ def remove_silent_frames(
     right_ear_clean: np.ndarray,
     left_ear_noisy: np.ndarray,
     right_ear_noisy: np.ndarray,
-    dynamic_range: np.ndarray,
-    frame_length: int,
-    hop: float,
+    dynamic_range: np.ndarray = 40,
+    frame_length: int = 256,
+    hop: float = 128,
 ):
     """Remove silent frames of x and y based on x
 
@@ -432,28 +377,20 @@ def remove_silent_frames(
     The frame exclusion is based solely on x, the clean speech signal
     Based on mpariente/pystoi/utils.py
 
-    Parameters
-    ----------
-    left_ear_clean: np.ndarray
-        clean input signal left channel
-    right_ear_clean: np.ndarray
-        clean input signal right channel
-    left_ear_noisy: ndarray
-        degraded/processed signal left channel
-    right_ear_noisy: ndarray
-        degraded/processed signal right channel
-    dyn_range: ndarray
-        range, energy range to determine which frame is silent, 40
-    framelen: int
-        N, window size for energy evaluation, 256
-    hop: int
-        K, hop size for energy evaluation, 128
+    Args:
+        left_ear_clean (np.ndarray) : Clean input signal left channel.
+        right_ear_clean (np.ndarray) : Clean input signal right channel.
+        left_ear_noisy (np.ndarray) : Degraded/processed signal left channel.
+        right_ear_noisy (np.ndarray) : Degraded/processed signal right channel.
+        dyn_range (np.ndarray) : Range, energy range to determine which frame is silent (default : 40).
+        framelen (int) : Window size for energy evaluation (default : 256).
+        hop (int) : Hop size for energy evaluation (default : 128).
 
     Returns :
-        xl (ndarray): xl without the silent frames
-        xr (ndarray): xr without the silent frames
-        yl (ndarray): yl without the silent frames in x
-        yl (ndarray): yl without the silent frames in x
+        xl_sil (np.ndarray): left_ear_clean without the silent frames.
+        xr_sil (np.ndarray): right_ear_clean without the silent frames.
+        yl_sil (np.ndarray): left_ear_noisy without the silent frames in xl_sil.
+        yr_sil (np.ndarray): right_ear_noisy without the silent frames in rl_sil.
     """
     dyn_range = int(dynamic_range)
     hop = int(hop)
@@ -522,23 +459,18 @@ def remove_silent_frames(
 def thirdoct(frequency_sampling: int, nfft: int, num_bands: int, min_freq: int):
     """Returns the 1/3 octave band matrix and its center frequencies based on mpariente/pystoi.
 
-    Parameters
-    ----------
-    fs: int
-        Frequency sampling rate.
-    n_fft: int
-        Number of FFT. FFT == ???
-    num_bands: int
-        Number of one-third octave bands.
-    min_freq: int
-        Center frequencey of the lowest one-third octave band.
+    Args:
+        fs (int) : Frequency sampling rate.
+        n_fft (int) : Number of FFT. FFT == ???
+        num_bands (int) : Number of one-third octave bands.
+        min_freq (int) : Center frequencey of the lowest one-third octave band.
 
-    Returns
-    -------
-    tuple: octave_band_matrix : np.ndarray, centre_frequencies: np.ndarray, frequency_band_edges_indices: np.ndarray,
-    freq_low: float, freq_high: fkiat
-        Tuple of Numpy arrays for  Octave Band Matrix, Center Frequencies, Indices of Frequency Band Edges, Low
-    frequency and High frequency.
+    Returns:
+        octave_band_matrix (np.ndarray) :
+        centre_frequencies (np.ndarray) : Centre frequencies.
+        frequency_band_edges_indices (np.ndarray) : Indices of Frequency Band Edges
+        freq_low (float) : Lowest frequency.
+        freq_high (float) : Highest frequency
     """
     # pylint: disable=invalid-name
     f = np.linspace(0, frequency_sampling, nfft + 1)
@@ -549,7 +481,7 @@ def thirdoct(frequency_sampling: int, nfft: int, num_bands: int, min_freq: int):
     freq_low = min_freq * np.power(2.0, (2 * k - 1) / 6)
     freq_high = min_freq * np.power(2.0, (2 * k + 1) / 6)
     octave_band_matrix = np.zeros((num_bands, len(f)))  # a verifier
-    firequency_band_edges_indices = np.zeros((num_bands, 2))
+    frequency_band_edges_indices = np.zeros((num_bands, 2))
 
     for i in range(len(centre_frequencies)):  # pylint: disable=invalid-name
         # Match 1/3 oct band freq with fft frequency bin
@@ -561,14 +493,14 @@ def thirdoct(frequency_sampling: int, nfft: int, num_bands: int, min_freq: int):
         fh_ii = f_bin
         # Assign to the octave band matrix
         octave_band_matrix[i, fl_ii:fh_ii] = 1
-        firequency_band_edges_indices[i, :] = [fl_ii + 1, fh_ii]
+        frequency_band_edges_indices[i, :] = [fl_ii + 1, fh_ii]
 
     centre_frequencies = centre_frequencies[np.newaxis, :]
 
     return (
         octave_band_matrix,
         centre_frequencies,
-        firequency_band_edges_indices,
+        frequency_band_edges_indices,
         freq_low,
         freq_high,
     )
@@ -577,15 +509,11 @@ def thirdoct(frequency_sampling: int, nfft: int, num_bands: int, min_freq: int):
 def find_delay_impulse(ddf: np.ndarray, initial_value: int = 22050):
     """Find binaural delay in signal ddf given initial location of unit impulse, initial_value.
 
-    Parameters
-    ----------
-    ddf: np.ndarray
-        ???
-    initial_value: int
-        Initial value (default: 22050)
+    Args:
+        ddf (np.ndarray) :
+        initial_value: (int) : Initial value (default: 22050)
 
-    Returns
-    -------
+    Returns:
 
     """
     pk0 = find_peaks(ddf[:, 0])

--- a/clarity/evaluator/mbstoi/parameters.yaml
+++ b/clarity/evaluator/mbstoi/parameters.yaml
@@ -1,0 +1,24 @@
+sample_rate: 10000  # sample rate of proposed intelligibility measure in hz
+n_frame: 256  # window support in samples
+fft_size_in_samples: 512  # fft size in samples
+n_third_octave_bands: 15  # number of one-third octave bands
+centre_freq_first_third_octave_hz: 150  # centre frequency of first 1/3 octave band in hz
+n_frames: 30  # number of frames for intermediate intelligibility measure (length analysis window)
+dyn_range: 40  # speech dynamic range in db
+# values to define ec grid
+tau_min: -0.001  # minimum interaural delay compensation in seconds. b: -0.01.
+tau_max: 0.001  # maximum interaural delay compensation in seconds. b: 0.01.
+gamma_min: -20  # minimum interaural level compensation in db
+gamma_max: 20  # maximum interaural level compensation in db
+# constants for jitter
+# itd compensation standard deviation in seconds. equation 6 andersen et al. 2018 refinement
+sigma_delta_0: 0.000065
+# ild compensation standard deviation.  equation 5 andersen et al. 2018
+sigma_epsilon_0: 1.5
+# constant for level shift deviation in db. equation 5 andersen et al. 2018
+alpha_0_db: 13
+# constant for time shift deviation in seconds. equation 6 andersen et al. 2018
+tau_0: 0.0016
+# constant for level shift deviation. power for calculation of sigma delta gamma
+# in equation 5 andersen et al. 2018.
+level_shift_deviation: 1.6

--- a/recipes/cec1/baseline/evaluate.py
+++ b/recipes/cec1/baseline/evaluate.py
@@ -162,7 +162,11 @@ def run_calculate_SI(cfg: DictConfig) -> None:
                 cfg["mbstoi"]["fs"],
                 cfg["mbstoi"]["gridcoarseness"],
             )
-            csv_lines.append([scene, listener, sii])
+            print(f"scene           : {scene}")
+            print(f"type(scene)     : {type(scene)}")
+            print(f"listener           : {listener}")
+            print(f"type(listener)     : {type(listener)}")
+            csv_lines.append([scene, listener, sii])  # type: ignore
 
     with open(sii_file, "w") as csv_f:
         csv_writer = csv.writer(

--- a/recipes/cec1/baseline/evaluate.py
+++ b/recipes/cec1/baseline/evaluate.py
@@ -162,10 +162,6 @@ def run_calculate_SI(cfg: DictConfig) -> None:
                 cfg["mbstoi"]["fs"],
                 cfg["mbstoi"]["gridcoarseness"],
             )
-            print(f"scene           : {scene}")
-            print(f"type(scene)     : {type(scene)}")
-            print(f"listener           : {listener}")
-            print(f"type(listener)     : {type(listener)}")
             csv_lines.append([scene, listener, sii])  # type: ignore
 
     with open(sii_file, "w") as csv_f:

--- a/recipes/cpc1/baseline/run.py
+++ b/recipes/cpc1/baseline/run.py
@@ -151,7 +151,7 @@ def run_calculate_SI(cfg, path) -> None:
             cfg["mbstoi"]["fs"],
             cfg["mbstoi"]["gridcoarseness"],
         )
-        csv_lines.append([f"{scene}_{listener}_{system}", sii])
+        csv_lines.append([f"{scene}_{listener}_{system}", sii])  # type: ignore
 
     with open(sii_file, "w") as csv_f:
         csv_writer = csv.writer(


### PR DESCRIPTION
First step in changing variable names to be more descriptive and "pythonic" (i.e. PEP8 compliant).

There are a few instances such as `for x...` where I have opted to disable the `pylint`/`flake8` check as they really don't make any difference.

I've tried to expand the docstrings too but there are still some gaps where I don't know what to write. 

Another perhaps unobvious change is that I've parameterised the values used in `mbstoi.py` such that they have defaults in the function but there is also a `parameters.yaml` which is loaded and used in the tests. This will allow future users to vary the values if desired. I'm not sure if that is something that would ever be likely to be done/needed but its good to have parameters with defaults rather than hard-coded variables.

Comments/feedback welcome, particularly on missing docstrings.