### PR TITLE
107 | Removing sphinx-markdown-tables patch from gh-pages build/deploy

### DIFF
--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -20,7 +20,6 @@ jobs:
           python-version: 3.9
       - name: Installing the Documentation requirements
         run: |
-          pip3 install git+https://github.com/Dzordzu/sphinx-markdown-tables.git@markdown-patch
           pip3 install .[docs]
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main


### PR DESCRIPTION
Closes #107