### PR TITLE
106 | Making device optional across modules and explicitly cpu in tests

### DIFF
--- a/clarity/enhancer/dsp/filter.py
+++ b/clarity/enhancer/dsp/filter.py
@@ -7,9 +7,12 @@ EPS = 1e-8
 
 
 class AudiometricFIR(nn.Module):
-    def __init__(self, sr=44100, nfir=220):
+    def __init__(self, sr=44100, nfir=220, device=None):
         super().__init__()
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        if device is not None:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        else:
+            self.device = device
         self.window_size = nfir + 1
         self.padding = nfir // 2
 

--- a/clarity/predictor/torch_msbg.py
+++ b/clarity/predictor/torch_msbg.py
@@ -163,13 +163,17 @@ class MSBGHearingModel(nn.Module):
         spl_cali=True,
         src_posn="ff",
         kernel_size=1025,
+        device=None,
     ):
         super().__init__()
         self.sr = sr
         self.spl_cali = spl_cali
         self.src_posn = src_posn
         self.kernel_size = kernel_size
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        if device is None:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        else:
+            self.device = device
 
         # settings for audiogram
 

--- a/tests/regression/test_enhancers.py
+++ b/tests/regression/test_enhancers.py
@@ -24,7 +24,7 @@ gha_params = {  # hyperparameters for GHA Hearing Aid, BE CAREFUL if making chan
 
 
 def test_dsp_filter(regtest):
-    amfir = filter.AudiometricFIR(sr=44100, nfir=220)
+    amfir = filter.AudiometricFIR(sr=44100, nfir=220, device="cpu")
     torch.manual_seed(0)
     signal = torch.rand(10, dtype=torch.float)
     signal = torch.reshape(signal, (1, 1, -1))

--- a/tests/regression/test_mc_conv_tasnet.py
+++ b/tests/regression/test_mc_conv_tasnet.py
@@ -35,6 +35,7 @@ def test_convtasnet(regtest):
         "norm_type": "cLN",
         "causal": True,
         "mask_nonlinear": "relu",
+        "device": "cpu",
     }
 
     cfg["test_dataset"] = {

--- a/tests/regression/test_predictors.py
+++ b/tests/regression/test_predictors.py
@@ -15,11 +15,9 @@ def test_torch_msbg_stoi(regtest):
 
     audiogram = [45, 35, 30, 45, 50, 50]
     audiometric = [250, 500, 1000, 2000, 4000, 6000]
-    msbg = MSBGHearingModel(audiogram=audiogram, audiometric=audiometric)
+    msbg = MSBGHearingModel(audiogram=audiogram, audiometric=audiometric, device="cpu")
 
     x = torch.randn(2, 44100)
-    if torch.cuda.is_available():
-        x = x.cuda()
     y = msbg(x)
     stoi_loss = stoi_loss.forward(x.cpu(), y.cpu()).mean()
     estoi_loss = estoi_loss.forward(x.cpu(), y.cpu()).mean()
@@ -36,8 +34,7 @@ def test_torchloudnorm(regtest):
     ln = torchloudnorm()
 
     x = torch.randn(2, 44100)
-    if torch.cuda.is_available():
-        x = x.cuda()
+    x = x.cpu()
     y = ln(x)
     div = (y / (x + 1e-8)).cpu().mean()
 


### PR DESCRIPTION
Closes #106 

Further to #101 this PR makes the `device` on which PyTorch tensors are run configurable across three modules.

Tests are then configured to explicitly use device "cpu" in the hope that it makes them configurable.