### PR TITLE
110 | Updating repo for flake8 in pre-commit; pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
         types: [python]
         additional_dependencies: ['click==8.0.4']
 
-  - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8.git
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-print]
@@ -60,6 +60,6 @@ repos:
 
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,6 @@ repos:
 
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v0.982
     hooks:
       - id: mypy


### PR DESCRIPTION
Closes #110 

Updating the `repo:` target for `flake8` in the `.pre-commit-config.yaml`. At the same time I've updated all other `rev:` of the enabled repositories/hooks.