### PR TITLE
Adding Badges to Head of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
-![PyTorch](https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=Flat&logo=PyTorch&logoColor=white)
-[![pytorch](https://img.shields.io/badge/PyTorch-1.8.0-EE4C2C.svg?style=flat&logo=pytorch)](https://pytorch.org)
 ![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 ## Machine learning challenges for hearing aid processing.
 
-<p align="center">
+<div align="center">
   <img src="docs/images/earfinal_clarity_customColour.png" alt="drawing" width="200" hspace="40"/>
 
   <img src="docs/images/cadenza_logo.png" alt="Cadenza Challenge" width="250" hspace="40"/>
-</p>
+
+[![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)
+
+![PyPI](https://img.shields.io/pypi/v/pyclarity?label=ICASSP%202023%20Challenge%20-%20pypi)
+![PyPI](https://img.shields.io/static/v1?label=CEC2%20Challenge%20-%20pypi&message=v0.1.1&color=orange)
+
+</div>
+
+--------------------------------------------------------------------------------
 
 We are organising a series of machine learning challenges to enhance hearing-aid signal processing and to better predict
 how people perceive speech-in-noise (Clarity) and speech-in-music (Cadenza). For further details of the Clarity Project

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
+![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
+![PyTorch](https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=Flat&logo=PyTorch&logoColor=white)
 ![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 <p>
 
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
-![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)](https://pypi.org/project/pyclarity/)
+[![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)](https://app.codecov.io/gh/claritychallenge/clarity)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)
 
-![PyPI](https://img.shields.io/pypi/v/pyclarity?label=ICASSP%202023%20Challenge%20-%20pypi)
-![PyPI](https://img.shields.io/static/v1?label=CEC2%20Challenge%20-%20pypi&message=v0.1.1&color=orange)
+[![PyPI](https://img.shields.io/static/v1?label=ICASSP%202023%20Challenge%20-%20pypi&message=v0.2.1&color=orange)](https://pypi.org/project/pyclarity/0.2.1/)
+[![PyPI](https://img.shields.io/static/v1?label=CEC2%20Challenge%20-%20pypi&message=v0.1.1&color=orange)](https://pypi.org/project/pyclarity/0.1.1/)
 </p>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
 ![PyTorch](https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=Flat&logo=PyTorch&logoColor=white)
+[![pytorch](https://img.shields.io/badge/PyTorch-1.8.0-EE4C2C.svg?style=flat&logo=pytorch)](https://pytorch.org)
 ![codecov.io](https://codecov.io/github/claritychallenge/clarity/coverage.svg?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Downloads](https://pepy.tech/badge/pyclarity)](https://pepy.tech/project/pyclarity)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-## Machine learning challenges for hearing aid processing.
-
 <div align="center">
+
+# Machine learning challenges for hearing aid processing.
+
   <img src="docs/images/earfinal_clarity_customColour.png" alt="drawing" width="200" hspace="40"/>
 
   <img src="docs/images/cadenza_logo.png" alt="Cadenza Challenge" width="250" hspace="40"/>
+
+<p>
 
 [![PyPI version](https://badge.fury.io/py/pyclarity.svg)](https://badge.fury.io/py/pyclarity)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyclarity)
@@ -12,6 +15,7 @@
 
 ![PyPI](https://img.shields.io/pypi/v/pyclarity?label=ICASSP%202023%20Challenge%20-%20pypi)
 ![PyPI](https://img.shields.io/static/v1?label=CEC2%20Challenge%20-%20pypi&message=v0.1.1&color=orange)
+</p>
 
 </div>
 


### PR DESCRIPTION
Signed-off-by: Gerardo Roa Dabike <gerardo.roa@gmail.com>
Closes #146 

PR is adding badges below the Clarity and Cadenza figures:

The current badges are:
* First row:
1. Last pip version
2. Python versions. The versions are obtained automatically, not sure yet how to specify a specific version like  ` 3.7 | 3.8 | 3.9 | 3.10`  Eg. like in https://github.com/asteroid-team/asteroid
3. Code style Black
4. Number of downloads

* Second Row
There are 2 badges that specify the pip version with the challenges. These are custom badges that we can change in colours and texts


Note, I didn't include this commit in @jonbarker68 Readme PR to avoid conflicts with that branch 