### PR TITLE
Enhance workflow to attach build artifacts to Release Notes

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -25,8 +25,14 @@ jobs:
       - name: Build package
         run: |
           python -m build --no-isolation
-      - name: Publish package
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Upload release artifacts to Release Notes
+        uses: Roang-zero1/github-upload-release-artifacts-action@v2
+        with:
+          args "dist/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #137

Uses the mentioned GitHub Action to attach the build artifacts (located under `build/`) to the release notes.