### PR TITLE
Removing redundant and outdated manual version from __init__.py

### DIFF
--- a/clarity/__init__.py
+++ b/clarity/__init__.py
@@ -1,6 +1,4 @@
 """pyClarity"""
-__version__ = "0.1.0"
-
 from . import _version
 
 __version__ = _version.get_versions()["version"]


### PR DESCRIPTION
Closes #150

Very minor, but there was a redundant line floating around that this PR removes.