### PR TITLE
Haaqi PEP8 nomenclature

### DIFF
--- a/clarity/evaluator/haaqi/haaqi.py
+++ b/clarity/evaluator/haaqi/haaqi.py
@@ -31,12 +31,12 @@ def haaqi_v1(
     Arguments:
     reference (ndarray):  Clear input reference speech signal with no noise or distortion.
             If a hearing loss is specified, NAL-R equalization is optional
-    reference_freq (int): Sampling rate in Hz for signal x
+    reference_freq (int): Sampling rate in Hz for reference signal.
     processed (np.ndarray):  Output signal with noise, distortion, HA gain, and/or processing.
-    processed_freq (int): Sampling rate in Hz for signal y.
+    processed_freq (int): Sampling rate in Hz for processed signal.
     hearling_loss (np.ndarray): (1,6) vector of hearing loss at the 6 audiometric frequencies
         [250, 500, 1000, 2000, 4000, 6000] Hz.
-    equaliser (int): Flag to provide equalization for the hearing loss to signal processed:
+    equalisation (int): Flag to provide equalization for the hearing loss to signal processed:
             1 = no EQ has been provided, the function will add NAL-R
             2 = NAL-R EQ has already been added to the reference signal
     level1 (int): Optional input specifying level in dB SPL that corresponds to a
@@ -62,7 +62,7 @@ def haaqi_v1(
     # Reference is no processing or NAL-R, impaired hearing
     (
         reference_db,
-        xbmreference_basilar_membrane,
+        reference_basilar_membrane,
         processed_db,
         processed_basilar_membrane,
         reference_sl,
@@ -99,7 +99,7 @@ def haaqi_v1(
     # Temporal fine structure (TFS) correlation measurements
     # Compute the time-frequency segment covariances
     signal_cross_covariance, reference_mean_square, _ = eb.bm_covary(
-        xbmreference_basilar_membrane,
+        reference_basilar_membrane,
         processed_basilar_membrane,
         segment_covariance,
         freq_sample,

--- a/clarity/evaluator/haaqi/haaqi.py
+++ b/clarity/evaluator/haaqi/haaqi.py
@@ -3,42 +3,52 @@ import numpy as np
 
 from clarity.evaluator.haspi import eb
 
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+
 
 def haaqi_v1(
-    x: np.ndarray,
-    fx: int,
-    y: np.ndarray,
-    fy: int,
-    hl: np.ndarray,
-    eq: int,
+    reference: np.ndarray,
+    reference_freq: int,
+    processed: np.ndarray,
+    processed_freq: int,
+    hearing_loss: np.ndarray,
+    equalisation: int,
     level1: int = 65,
+    silence_threshold: float = 2.5,
+    add_noise: float = 0.0,
+    segment_covariance: int = 16,
 ):
     """
-    Compute the HAAQI music quality index using the
-    auditory model followed by computing the envelope cepstral
-    correlation and BM vibration average short-time coherence signals.
+    Compute the HAAQI music quality index using the auditory model followed by
+    computing the envelope cepstral correlation and Basilar Membrane vibration
+    average short-time coherence signals.
+
     The reference signal presentation level for NH listeners is assumed
     to be 65 dB SPL. The same model is used for both normal and
     impaired hearing.
 
     Arguments:
-        x (ndarray):  Clear input reference speech signal with no noise or distortion.
+    reference (ndarray):  Clear input reference speech signal with no noise or distortion.
             If a hearing loss is specified, NAL-R equalization is optional
-        fx (int): Sampling rate in Hz for signal x
-        y (np.ndarray):  Output signal with noise, distortion, HA gain, and/or processing.
-        fy (int): Sampling rate in Hz for signal y.
-        hl (np.ndarray): (1,6) vector of hearing loss at the 6 audiometric frequencies
+    reference_freq (int): Sampling rate in Hz for signal x
+    processed (np.ndarray):  Output signal with noise, distortion, HA gain, and/or processing.
+    processed_freq (int): Sampling rate in Hz for signal y.
+    hearling_loss (np.ndarray): (1,6) vector of hearing loss at the 6 audiometric frequencies
         [250, 500, 1000, 2000, 4000, 6000] Hz.
-        eq (int): Flag to provide equalization for the hearing loss to signal x:
+    equaliser (int): Flag to provide equalization for the hearing loss to signal processed:
             1 = no EQ has been provided, the function will add NAL-R
             2 = NAL-R EQ has already been added to the reference signal
-        level1 (int): Optional input specifying level in dB SPL that corresponds to a
+    level1 (int): Optional input specifying level in dB SPL that corresponds to a
            signal RMS = 1. Default is 65 dB SPL if argument not provided.
            Default: 65
+    silence_threshold (float): Silence threshold sum across bands, dB above aud threshold. Default : 2.5
+    add_noise (float): Additive noise in dB SL to condition cross-covariances. Default: 0.0
+    segment_covariance (int): Segment size for the covariance calculation. Default: 16
 
     Returns:
-        combined : Quality is the polynomial sum of the nonlin and linear terms
-        nonlin : Nonlinear quality component = .245(BMsync5) + .755(CepHigh)^3
+        combined : Quality is the polynomial sum of the nonlinear and linear terms
+        nonlinear : Nonlinear quality component = .245(BMsync5) + .755(CepHigh)^3
         linear : Linear quality component = std of spectrum and norm spectrum
         raw : Vector of raw values = [cephigh, bmsync5, dloud, dnorm]
 
@@ -50,73 +60,90 @@ def haaqi_v1(
 
     # Auditory model for quality
     # Reference is no processing or NAL-R, impaired hearing
-    xenv, xbm, yenv, ybm, xsl, ysl, fsamp = eb.ear_model(x, fx, y, fy, hl, eq, level1)
+    (
+        reference_db,
+        xbmreference_basilar_membrane,
+        processed_db,
+        processed_basilar_membrane,
+        reference_sl,
+        processed_sl,
+        freq_sample,
+    ) = eb.ear_model(
+        reference,
+        reference_freq,
+        processed,
+        processed_freq,
+        hearing_loss,
+        equalisation,
+        level1,
+    )
 
     # ---------------------------------------
     # Envelope and long-term average spectral features
     # Smooth the envelope outputs: 250 Hz sub-sampling rate
-    segsize = 8  # Averaging segment size in msec
-    xdb = eb.env_smooth(xenv, segsize, fsamp)
-    ydb = eb.env_smooth(yenv, segsize, fsamp)
+    segment_size = 8  # Averaging segment size in msec
+    reference_smooth = eb.env_smooth(reference_db, segment_size, freq_sample)
+    processed_smooth = eb.env_smooth(processed_db, segment_size, freq_sample)
 
     # Mel cepstrum correlation after passing through modulation filterbank
-    thr = 2.5  # Silence threshold: sum across bands, dB above aud threshold
-    addnoise = 0.0  # dditive noise in dB SL to condition cross-covariances
-    _, _, cephigh, _ = eb.melcor9(
-        xdb, ydb, thr, addnoise, segsize
+    _, _, mel_cepstral_high, _ = eb.melcor9(
+        reference_smooth, processed_smooth, silence_threshold, add_noise, segment_size
     )  # 8 modulation freq bands
 
     # Linear changes in the long-term spectra
     # dloud  vector: [sum abs diff, std dev diff, max diff] spectra
     # dnorm  vector: [sum abs diff, std dev diff, max diff] norm spectra
     # dslope vector: [sum abs diff, std dev diff, max diff] slope
-    dloud_vector, dnorm_vector, _ = eb.spectrum_diff(xsl, ysl)
+    dloud_vector, dnorm_vector, _ = eb.spectrum_diff(reference_sl, processed_sl)
 
     # Temporal fine structure (TFS) correlation measurements
     # Compute the time-frequency segment covariances
-    segcov = 16  # Segment size for the covariance calculation
-    sigcov, sigmsx, _ = eb.bm_covary(xbm, ybm, segcov, fsamp)
+    signal_cross_covariance, reference_mean_square, _ = eb.bm_covary(
+        xbmreference_basilar_membrane,
+        processed_basilar_membrane,
+        segment_covariance,
+        freq_sample,
+    )
 
     # Average signal segment cross-covariance
     # avecov=weighted ave of cross-covariances, using only data above threshold
     # syncov=ave cross-covariance with added IHC loss of synchronization at HF
-    thr = 2.5  # Threshold in dB SL for including time-freq tile
-    _, syncov = eb.ave_covary2(sigcov, sigmsx, thr)
-    bmsync5 = syncov[4]  # Ave segment coherence with IHC loss of sync
+    _, ihc_sync_covariance = eb.ave_covary2(
+        signal_cross_covariance, reference_mean_square, silence_threshold
+    )
+    basilar_membrane_sync5 = ihc_sync_covariance[
+        4
+    ]  # Ave segment coherence with IHC loss of sync
 
     # Extract and normalize the spectral features
     # Dloud:std
-    d = dloud_vector[1]  # Loudness difference std
-    d = d / 2.5  # Scale the value
-    d = 1.0 - d  # 1=perfect, 0=bad
-    d = min(d, 1)
-    d = max(d, 0)
-    dloud = d
+    d_loud = dloud_vector[1] / 2.5  # Loudness difference std
+    d_loud = 1.0 - d_loud  # 1=perfect, 0=bad
+    d_loud = min(d_loud, 1)
+    d_loud = max(d_loud, 0)
 
     # Dnorm:std
-    d = dnorm_vector[1]  # Slope difference std
-    d = d / 25  # Scale the value
-    d = 1.0 - d  # 1=perfect, 0=bad
-    d = min(d, 1)
-    d = max(d, 0)
-    dnorm = d
+    d_norm = dnorm_vector[1] / 25  # Slope difference std
+    d_norm = 1.0 - d_norm  # 1=perfect, 0=bad
+    d_norm = min(d_norm, 1)
+    d_norm = max(d_norm, 0)
 
     # Construct the models
-    # Nonlinear model
-    nonlin_model = 0.754 * (cephigh**3) + 0.246 * bmsync5  # Combined envelope and TFS
+    # Nonlinear model - Combined envelope and TFS
+    nonlinear_model = 0.754 * (mel_cepstral_high**3) + 0.246 * basilar_membrane_sync5
 
     # Linear model
-    lin_model = 0.329 * dloud + 0.671 * dnorm  # Linear fit
+    linear_model = 0.329 * d_loud + 0.671 * d_norm
 
     # Combined model
-    combined = (
-        0.336 * nonlin_model
-        + 0.001 * lin_model
-        + 0.501 * (nonlin_model**2)
-        + 0.161 * (lin_model**2)
+    combined_model = (
+        0.336 * nonlinear_model
+        + 0.001 * linear_model
+        + 0.501 * (nonlinear_model**2)
+        + 0.161 * (linear_model**2)
     )  # Polynomial sum
 
     # Raw data
-    raw = [cephigh, bmsync5, dloud, dnorm]
+    raw = [mel_cepstral_high, basilar_membrane_sync5, d_loud, d_norm]
 
-    return combined, nonlin_model, lin_model, raw
+    return combined_model, nonlinear_model, linear_model, raw

--- a/clarity/evaluator/haspi/ebm.py
+++ b/clarity/evaluator/haspi/ebm.py
@@ -340,28 +340,28 @@ def fir_modulation_filter(
 
 def modulation_cross_correlation(reference_modulation, processed_modulation):
     """
-    Compute the cross-correlations between the input signal time-frequency
-    envelope and the distortion time-frequency envelope. The cepstral
-    coefficients or envelopes in each frequency band have been passed
-    through the modulation filterbank using function ebm_ModFilt.
+     Compute the cross-correlations between the input signal time-frequency
+     envelope and the distortion time-frequency envelope. The cepstral
+     coefficients or envelopes in each frequency band have been passed
+     through the modulation filterbank using function ebm_ModFilt.
 
-    Args:
-        Xmod (np.array): cell array containing the reference signal output of the
-             modulation filterbank. Xmod is of size {nchan,nmodfilt} where
-             nchan is the number of frequency channels or cepstral basis
-             functions in Xenv, and nmodfilt is the number of modulation
-             filters used in the analysis. Each cell contains a column vector
-             of length nsamp, where nsamp is the number of samples in each
-             envelope sequence contained in the columns of Xenv.
-        Ymod subsampled distorted output signal envelope
+     Args:
+     reference_modulation (np.array): cell array containing the reference signal output of the
+              modulation filterbank. Xmod is of size {nchan,nmodfilt} where
+              nchan is the number of frequency channels or cepstral basis
+              functions in Xenv, and nmodfilt is the number of modulation
+              filters used in the analysis. Each cell contains a column vector
+              of length nsamp, where nsamp is the number of samples in each
+              envelope sequence contained in the columns of Xenv.
+    processed_modulation (np.ndarray): subsampled distorted output signal envelope
 
-    Output:
-        float: aveCM modulation correlations averaged over basis functions 2-6
-             vector of size nmodfilt
+     Output:
+         float: aveCM modulation correlations averaged over basis functions 2-6
+              vector of size nmodfilt
 
-    Updates:
-    James M. Kates, 21 February 2019.
-    Translated from MATLAB to Python by Zuzanna Podwinska, March 2022.
+     Updates:
+     James M. Kates, 21 February 2019.
+     Translated from MATLAB to Python by Zuzanna Podwinska, March 2022.
     """
     # Processing parameters
     nchan = reference_modulation.shape[0]  # Number of basis functions


### PR DESCRIPTION
Another step along the renaming path, this time for the `clarity.evaluator.haaqu.haaqi` sub-module.

A lot smaller this one!