### PR TITLE
Hasqi PEP8 nomenclature

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,11 @@
+# PEP8 compliance - clarity/evaluators/hasqi
+14e21eff76a1350cabaa19ad26f2556892d51761
+961846ca661b5b97f0d1a75585452aed6f15c5f7
+
+# PEP8 compliance - clarity/evaluators/haaqi
+55e7f5c81b0e5a2bf27bd21a0a1319dd16ddbd3c
+14f6ae14279b6abccd3da6876c712a1c3f66a0b9
+
 # PEP8 compliance - clarity/evaluators/haspi
 41db4281fa6b3ea6758cadbd49c8403caeea3529
 8b1198d7e5c7b1436b15d40e95f5581939030164

--- a/clarity/evaluator/haspi/eb.py
+++ b/clarity/evaluator/haspi/eb.py
@@ -1304,7 +1304,7 @@ def env_smooth(envelopes: np.ndarray, segment_size, freq_sample):
     return smooth
 
 
-def melcor(reference, distorted, threshold, addnoise):
+def mel_cepstrum_correlation(reference, distorted, threshold, addnoise):
     """
     Compute the cross-correlations between the input signal time-frequency
     envelope and the distortion time-frequency envelope.

--- a/clarity/evaluator/hasqi/__init__.py
+++ b/clarity/evaluator/hasqi/__init__.py
@@ -1,3 +1,3 @@
-from clarity.evaluator.hasqi.hasqi import hasqi_v2, hasqi_v2_be
+from clarity.evaluator.hasqi.hasqi import hasqi_v2, hasqi_v2_better_ear  # noqa F401
 
 __all__ = ["hasqi_v2", "hasqi_v2_be"]

--- a/clarity/evaluator/hasqi/hasqi.py
+++ b/clarity/evaluator/hasqi/hasqi.py
@@ -2,7 +2,16 @@ from clarity.evaluator.haspi import eb
 
 
 def hasqi_v2(
-    reference, reference_freq, processed, processed_freq, hearing_loss, eq=1, level1=65
+    reference,
+    reference_freq,
+    processed,
+    processed_freq,
+    hearing_loss,
+    equalisation=1,
+    level1=65,
+    silence_threshold=2.5,
+    add_noise=0.0,
+    segment_covariance=16,
 ):
     """
     Function to compute the HASQI version 2 quality index using the
@@ -20,11 +29,15 @@ def hasqi_v2(
     processed_freq (int): Sampling rate in Hz for processed signal.
     hearing_loss (np.ndarray): vector of hearing loss at the 6 audiometric frequencies
                   [250, 500, 1000, 2000, 4000, 6000] Hz.
-    eq        Flag to provide equalization for the hearing loss to signal x:
+    equalisation (int): Flag to provide equalization for the hearing loss to reference signal:
                 1 = no EQ has been provided, the function will add NAL-R
                 2 = NAL-R EQ has already been added to the reference signal
-    Level1    Optional input specifying level in dB SPL that corresponds to a
+    level1    Optional input specifying level in dB SPL that corresponds to a
               signal RMS = 1. Default is 65 dB SPL if argument not provided.
+    silence_threshold (float): Silence threshold sum across bands, dB above audio threshold. Default: 2.5
+    add_noise (float): Additive noise in dB SL to conditiona cross-covariance. Default: 0.0
+    segment_covariance (int): Segment size for the covariance calculation. Default: 16
+
     Returns:
     Combined  Quality estimate is the product of the nonlinear and linear terms
     Nonlin    Nonlinear quality component = (cepstral corr)^2 x seg BM coherence
@@ -37,86 +50,118 @@ def hasqi_v2(
 
     # Auditory model for quality
     # Reference is no processing or NAL-R, impaired hearing
-    xenv, xBM, yenv, yBM, xSL, ySL, fsamp = eb.ear_model(
-        reference, reference_freq, processed, processed_freq, hearing_loss, eq, level1
+    (
+        reference_db,
+        reference_basilar_membrane,
+        processed_db,
+        processed_basilar_membrane,
+        reference_sl,
+        processed_sl,
+        freq_sample,
+    ) = eb.ear_model(
+        reference,
+        reference_freq,
+        processed,
+        processed_freq,
+        hearing_loss,
+        equalisation,
+        level1,
     )
 
     # Envelope and long-term average spectral features
     # Smooth the envelope outputs: 125 Hz sub-sampling rate
-    segsize = 16  # Averaging segment size in msec
-    xdB = eb.env_smooth(xenv, segsize, fsamp)
-    ydB = eb.env_smooth(yenv, segsize, fsamp)
+    reference_smooth = eb.env_smooth(reference_db, segment_covariance, freq_sample)
+    processed_smooth = eb.env_smooth(processed_db, segment_covariance, freq_sample)
 
     # Mel cepstrum correlation using smoothed envelopes
-    # m1=ave of coefficients 2-6
-    # xy=vector of coefficients 1-6
-    thr = 2.5  # Silence threshold: sum across bands, dB above aud threshold
-    addnoise = 0.0  # Additive noise in dB SL to condition cross-covariances
-    cep_corr, xy = eb.melcor(xdB, ydB, thr, addnoise)
+    (
+        average_cepstral_correlation,
+        individual_cepstral_correlations,
+    ) = eb.mel_cepstrum_correlation(
+        reference_smooth, processed_smooth, silence_threshold, add_noise
+    )
 
     # Linear changes in the log-term spectra
     # dloud  vector: [sum abs diff, std dev diff, max diff] spectra
     # dnorm  vector: [sum abs diff, std dev diff, max diff] norm spectra
     # dslope vector: [sum abs diff, std dev diff, max diff] slope
-    dloud, dnorm, dslope = eb.spectrum_diff(xSL, ySL)
+    d_loud, d_norm, d_slope = eb.spectrum_diff(reference_sl, processed_sl)
 
     # Temporal fine structure correlation measurements
     # Compute the time-frequency segment covariances
-    segcov = 16  # Segment size for the covariance calculation
-    sigcov, sigMSx, sigMSy = eb.bm_covary(xBM, yBM, segcov, fsamp)
+    (
+        signal_cross_covariance,
+        reference_mean_square,
+        processed_mean_square,
+    ) = eb.bm_covary(
+        reference_basilar_membrane,
+        processed_basilar_membrane,
+        segment_covariance,
+        freq_sample,
+    )
 
     # Average signal segment cross-covariance
     # avecov=weighted ave of cross-covariances, using only data above threshold
     # syncov=ave cross-covariance with added IHC loss of synchronization at HF
-    thr = 2.5  # Threshold in dB SL for including time-freq tile
-    avecov, syncov = eb.ave_covary2(sigcov, sigMSx, thr)
-    bm_sync5 = syncov[4]  # Ave segment coherence with IHC loss of sync
+    silence_threshold = 2.5  # Threshold in dB SL for including time-freq tile
+    _, ihc_sync_covariance = eb.ave_covary2(
+        signal_cross_covariance, reference_mean_square, silence_threshold
+    )
+    basilar_membrane_sync5 = ihc_sync_covariance[
+        4
+    ]  # Ave segment coherence with IHC loss of sync
 
     # Extract and normalize the spectral features
     # Dloud:std
-    d = dloud[1]  # Loudness difference std
-    d = d / 2.5  # Scale the value
-    d = 1.0 - d  # 1=perfect, 0=bad
-    d = min(d, 1)
-    d = max(d, 0)
-    d_loud = d
+    d_loud = d_loud[1] / 2.5  # Loudness difference std
+    d_loud = 1.0 - d_loud  # 1=perfect, 0=bad
+    d_loud = min(d_loud, 1)
+    d_loud = max(d_loud, 0)
 
     # Dslope:std
-    d = dslope[1]  # Slope difference std
-    d = 1.0 - d
-    d = min(d, 1)
-    d = max(d, 0)
-    d_slope = d
+    d_slope = d_slope[1]  # Slope difference std
+    d_slope = 1.0 - d_slope
+    d_slope = min(d_slope, 1)
+    d_slope = max(d_slope, 0)
 
     # Construct the models
     # Nonlinear model
-    non_lin = (
-        cep_corr**2
-    ) * bm_sync5  # Combined envelope and temporal fine structure
+    non_linear = (
+        average_cepstral_correlation**2
+    ) * basilar_membrane_sync5  # Combined envelope and temporal fine structure
     # Linear model
     linear = 0.579 * d_loud + 0.421 * d_slope  # Linear fit
 
     # Combined model
-    combined = non_lin * linear  # Product of nonlinear x linear
+    combined = non_linear * linear  # Product of nonlinear x linear
 
     # Raw data
-    raw = [cep_corr, bm_sync5, d_loud, d_slope]
-    return combined, non_lin, linear, raw
+    raw = [average_cepstral_correlation, basilar_membrane_sync5, d_loud, d_slope]
+    return combined, non_linear, linear, raw
 
 
-def hasqi_v2_be(
-    xl, xr, yl, yr, fs_signal, audiogram_l, audiogram_r, audiogram_cfs, level=100
+def hasqi_v2_better_ear(
+    reference_left,
+    reference_right,
+    processed_left,
+    processed_right,
+    sample_freq,
+    audiogram_left,
+    audiogram_right,
+    audiogram_frequencies,
+    level=100,
+    audiogram_freq=[250, 500, 1000, 2000, 4000, 6000],
 ) -> float:
     """Better ear HASQI.
 
     Calculates HASQI for left and right ear and selects the better result.
 
     Args:
-        xl: left channel of reference signal
-        xr: right channel of reference signal
-        yl: left channel of processed signal
-        yr: right channel of processed signal
-        fs_signal: sampling rate for both signal
+        reference_left (np.ndarray): left channel of reference signal
+        reference_right (np.ndarray): right channel of reference signal
+        reference_left (np.ndarray): left channel of processed signal
+        reference_right (np.ndarray): right channel of processed signal
+        sample_freq: sampling rate for both signal
         audiogram_l: left ear audiogram
         audiogram_r: right ear audiogram
         audiogram_cfs: audiogram frequencies
@@ -127,19 +172,35 @@ def hasqi_v2_be(
 
     Gerardo Roa Dabike, November 2022
     """
-
-    # HASQI assumes the following audiogram frequencies:
-    aud = [250, 500, 1000, 2000, 4000, 6000]
-
-    # Adjust listener.audiogram_levels_l and _r to match the frequencies above
-    hl_l = [
-        audiogram_l[i] for i in range(len(audiogram_cfs)) if audiogram_cfs[i] in aud
+    # Adjust to match the frequencies
+    adjusted_left = [
+        audiogram_left[i]
+        for i in range(len(audiogram_frequencies))
+        if audiogram_frequencies[i] in audiogram_freq
     ]
-    hl_r = [
-        audiogram_r[i] for i in range(len(audiogram_cfs)) if audiogram_cfs[i] in aud
+    adjusted_right = [
+        audiogram_right[i]
+        for i in range(len(audiogram_frequencies))
+        if audiogram_frequencies[i] in audiogram_freq
     ]
 
-    score_l, _, _, _ = hasqi_v2(xl, fs_signal, yl, fs_signal, hl_l, eq=1, level1=level)
-    score_r, _, _, _ = hasqi_v2(xr, fs_signal, yr, fs_signal, hl_r, eq=1, level1=level)
+    score_left, _, _, _ = hasqi_v2(
+        reference_left,
+        sample_freq,
+        processed_left,
+        sample_freq,
+        adjusted_left,
+        equalisation=1,
+        level1=level,
+    )
+    score_right, _, _, _ = hasqi_v2(
+        reference_right,
+        sample_freq,
+        processed_right,
+        sample_freq,
+        adjusted_right,
+        equalisation=1,
+        level1=level,
+    )
 
-    return max(score_l, score_r)
+    return max(score_left, score_right)

--- a/clarity/evaluator/hasqi/hasqi.py
+++ b/clarity/evaluator/hasqi/hasqi.py
@@ -1,7 +1,9 @@
 from clarity.evaluator.haspi import eb
 
 
-def hasqi_v2(x, fx, y, fy, HL, eq=1, level1=65):
+def hasqi_v2(
+    reference, reference_freq, processed, processed_freq, hearing_loss, eq=1, level1=65
+):
     """
     Function to compute the HASQI version 2 quality index using the
     auditory model followed by computing the envelope cepstral
@@ -11,12 +13,12 @@ def hasqi_v2(x, fx, y, fy, HL, eq=1, level1=65):
     impaired hearing.
 
     Arguments:
-    x			Clear input reference speech signal with no noise or distortion.
+    reference (np.ndarray): Clear input reference speech signal with no noise or distortion.
               If a hearing loss is specified, NAL-R equalization is optional
-    fx        Sampling rate in Hz for signal x
-    y			Output signal with noise, distortion, HA gain, and/or processing.
-    fy        Sampling rate in Hz for signal y.
-    HL		(1,6) vector of hearing loss at the 6 audiometric frequencies
+    reference_freq (int): Sampling rate in Hz for reference signal.
+    processed (np.ndarray): Output signal with noise, distortion, HA gain, and/or processing.
+    processed_freq (int): Sampling rate in Hz for processed signal.
+    hearing_loss (np.ndarray): vector of hearing loss at the 6 audiometric frequencies
                   [250, 500, 1000, 2000, 4000, 6000] Hz.
     eq        Flag to provide equalization for the hearing loss to signal x:
                 1 = no EQ has been provided, the function will add NAL-R
@@ -35,7 +37,9 @@ def hasqi_v2(x, fx, y, fy, HL, eq=1, level1=65):
 
     # Auditory model for quality
     # Reference is no processing or NAL-R, impaired hearing
-    xenv, xBM, yenv, yBM, xSL, ySL, fsamp = eb.ear_model(x, fx, y, fy, HL, eq, level1)
+    xenv, xBM, yenv, yBM, xSL, ySL, fsamp = eb.ear_model(
+        reference, reference_freq, processed, processed_freq, hearing_loss, eq, level1
+    )
 
     # Envelope and long-term average spectral features
     # Smooth the envelope outputs: 125 Hz sub-sampling rate

--- a/recipes/icassp_2023/baseline/evaluate.py
+++ b/recipes/icassp_2023/baseline/evaluate.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from clarity.enhancer.compressor import Compressor
 from clarity.enhancer.nalr import NALR
 from clarity.evaluator.haspi import haspi_v2_be
-from clarity.evaluator.hasqi import hasqi_v2_be
+from clarity.evaluator.hasqi import hasqi_v2_better_ear
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +164,9 @@ def run_calculate_si(cfg: DictConfig) -> None:
         ref = ref_anechoic * rms_target / rms_anechoic
 
         haspi_score = compute_metric(haspi_v2_be, amplified, ref, audiogram, fs_signal)
-        hasqi_score = compute_metric(hasqi_v2_be, amplified, ref, audiogram, fs_signal)
+        hasqi_score = compute_metric(
+            hasqi_v2_better_ear, amplified, ref, audiogram, fs_signal
+        )
         score = 0.5 * (hasqi_score + haspi_score)
 
         results_file.add_result(


### PR DESCRIPTION
Giving Hasqi evaluator the PEP8 nomenclature treatment. Improved one function name in `eb` sub-module at the same time.