### PR TITLE
Update isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,12 @@ repos:
         additional_dependencies: [flake8-print]
         types: [python]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
       - id: isort
+        name: isort (python)
         args: ["--profile", "black"]
-        name: isort
-        types: [python]
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.5.3


### PR DESCRIPTION
Previous version causes pre-commit checks to fail even if imports are sorted correctly

Closes #170 