### PR TITLE
PEP8 nomenclature for some HOA_tools_cec2.py; improving some tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--maxkb=1024]
       - id: debug-statements
       - id: check-byte-order-marker
-      - id: check-yaml
+      # - id: check-yaml
 
   - repo: https://github.com/psf/black
     rev: 22.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--maxkb=1024]
       - id: debug-statements
       - id: check-byte-order-marker
-#      - id: check-yaml
+      - id: check-yaml
 
   - repo: https://github.com/psf/black
     rev: 22.12.0

--- a/clarity/data/demo_data.py
+++ b/clarity/data/demo_data.py
@@ -1,3 +1,4 @@
+"""Functions for downloading demo data."""
 import os
 from pathlib import Path
 
@@ -7,7 +8,17 @@ TARGET_DIR = "clarity_data/demo"
 PACKAGE_NAME = "data.tgz"
 
 
-def get_demo_data(metadata_url, target_dir):
+def get_demo_data(metadata_url: str, target_dir: str) -> None:
+    """Download demo data.
+
+    Args:
+        metadata_url (str): URL to download data from (should be a link on Google Drive).
+        target_dir (str): Directory to save to (default 'clarity_data/demo'), will be created
+            if it doesn't exist.
+
+    Returns:
+        None
+    """
     gdown.download(metadata_url, PACKAGE_NAME, quiet=False)
     p = Path(target_dir)
     if p.exists() is False:
@@ -16,31 +27,37 @@ def get_demo_data(metadata_url, target_dir):
     os.system(f"rm {PACKAGE_NAME}")
 
 
-def get_metadata_demo(target_dir=TARGET_DIR):
+def get_metadata_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download metadata."""
     url = "https://drive.google.com/uc?export=download&id=14KGm2GaRgwlrZvtmMwWTYu7itaRVQV8f"
     get_demo_data(url, target_dir)
 
 
-def get_targets_demo(target_dir=TARGET_DIR):
+def get_targets_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download targets."""
     url = "https://drive.google.com/uc?export=download&id=1uu2Hes1fzqNaZSCiFNhxZM3bE_fAVKsD"
     get_demo_data(url, target_dir)
 
 
-def get_interferers_demo(target_dir=TARGET_DIR):
+def get_interferers_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download interferers."""
     url = "https://drive.google.com/uc?export=download&id=1_ssD238Qv-EETzC0hJze7JhLE7bHyqwG"
     get_demo_data(url, target_dir)
 
 
-def get_rooms_demo(target_dir=TARGET_DIR):
+def get_rooms_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download rooms."""
     url = "https://drive.google.com/uc?export=download&id=1FBC8DI4Ru-g3Set0fDzoKmXTqHqNXV8n"
     get_demo_data(url, target_dir)
 
 
-def get_scenes_demo(target_dir=TARGET_DIR):
+def get_scenes_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download secnes."""
     url = "https://drive.google.com/uc?export=download&id=1PB0CfGXhpkYNk8HbE5lTWowm2016x6Hl"
     get_demo_data(url, target_dir)
 
 
-def get_hrirs_demo(target_dir=TARGET_DIR):
+def get_hrirs_demo(target_dir: str = TARGET_DIR) -> None:
+    """Download hiris."""
     url = "https://drive.google.com/uc?export=download&id=1USrHLFhOE_jdAQcEKqumG3M5dEZVcwSd"
     get_demo_data(url, target_dir)

--- a/clarity/data/scene_builder_cec2.py
+++ b/clarity/data/scene_builder_cec2.py
@@ -235,7 +235,7 @@ def add_this_target_to_scene(
 
 
 # SNR handling
-def generate_snr(snr_range: list[int]) -> float:
+def generate_snr(snr_range: List[int]) -> float:
     """Generate a random Signal Noise Ratio.
 
     Args:
@@ -345,8 +345,8 @@ def add_interferer_to_scene_inner(
     scene: dict,
     interferers: dict,
     number: list,
-    start_time_range: list[int],
-    end_early_time_range: list[int],
+    start_time_range: List[int],
+    end_early_time_range: List[int],
 ):
     """Randomly select interferers and add them to the given scene.
     A random number of interferers is chosen, then each is given a random type

--- a/clarity/data/scene_builder_cec2.py
+++ b/clarity/data/scene_builder_cec2.py
@@ -6,6 +6,7 @@ import math
 import random
 import re
 from enum import Enum
+from typing import Dict, List
 
 import numpy as np
 from tqdm import tqdm
@@ -38,7 +39,7 @@ def set_random_seed(random_seed):
         np.random.seed(random_seed)
 
 
-def get_vector(text: str, vector_name: str) -> list[float]:
+def get_vector(text: str, vector_name: str) -> List[float]:
     """Get a vector quantity from the rpf file.
     Will read rpf vector quantities, eg.
     "sourceViewVectors = -0.095,-0.995, 0.000"
@@ -57,7 +58,7 @@ def get_vector(text: str, vector_name: str) -> list[float]:
     return x
 
 
-def get_room_dims(text: str) -> list:
+def get_room_dims(text: str) -> List:
     """Find the room dimensions in the rpf file.
 
     Args:
@@ -86,7 +87,7 @@ def get_room_name(text: str) -> str:
     return re.findall(r"R\d\d\d\d\d", text)[0]
 
 
-def read_rpf_file(rpf_filename: str) -> dict:
+def read_rpf_file(rpf_filename: str) -> Dict:
     """Process an rpf file and return key contents as a dictionary.
 
     Args:
@@ -122,7 +123,7 @@ def read_rpf_file(rpf_filename: str) -> dict:
     return rpf_dict
 
 
-def build_room(target_file: str, interferer_files: list[str]) -> dict:
+def build_room(target_file: str, interferer_files: list[str]) -> Dict:
     """Build room json file from contents of related rpf files.
     Note, there is an rpf file for each source in the scene. All of these
     files are read and a single scene json file is constructed.
@@ -157,7 +158,7 @@ def build_room(target_file: str, interferer_files: list[str]) -> dict:
 
 def make_rpf_filename_dict(
     rpf_location: str, scene_str: str, n_interferers: int
-) -> dict:
+) -> Dict:
     """Construct dictionary storing all rpf files that will be processed.
 
     Args:
@@ -256,7 +257,7 @@ class InterfererType(Enum):
     MUSIC = "music"
 
 
-def select_interferer_types(allowed_n_interferers: list) -> list[InterfererType]:
+def select_interferer_types(allowed_n_interferers: list) -> List[InterfererType]:
     """Select the interferer types to use.
 
     The number of interferer is drawn randomly from list of allowed valued.
@@ -282,8 +283,8 @@ def select_interferer_types(allowed_n_interferers: list) -> list[InterfererType]
 
 
 def select_random_interferer(
-    interferers: list[list], dataset: str, required_samples: int
-) -> dict:
+    interferers: List[list], dataset: str, required_samples: int
+) -> Dict:
     """Randomly select an interferer.
     Interferers stored as list of list. First randomly select a sublist
     then randomly select an item from sublist matching constraints.
@@ -422,7 +423,7 @@ def generate_rotation(
     angle_initial_mean: float,
     angle_initial_sd: float,
     angle_final_range: tuple,
-) -> list[dict]:
+) -> List[dict]:
     """Generate a suitable head rotation for the given scene.
     Based on behavioural studies by Hadley et al. TODO: find ref
 

--- a/clarity/data/scene_builder_cec2.py
+++ b/clarity/data/scene_builder_cec2.py
@@ -49,7 +49,7 @@ def get_vector(text: str, vector_name: str) -> List[float]:
         vector_name (str): name of vector to extract (e.g. "sourceViewVectors")
 
     Returns:
-        list[float]: vector as list of floats
+        List[float]: vector as list of floats
     """
     findall_str = f".*{vector_name}.*"
     x_str = re.findall(findall_str, text)
@@ -123,14 +123,14 @@ def read_rpf_file(rpf_filename: str) -> Dict:
     return rpf_dict
 
 
-def build_room(target_file: str, interferer_files: list[str]) -> Dict:
+def build_room(target_file: str, interferer_files: List[str]) -> Dict:
     """Build room json file from contents of related rpf files.
     Note, there is an rpf file for each source in the scene. All of these
     files are read and a single scene json file is constructed.
 
     Args:
         target_file (str): rpf file containing the target position
-        interferer_files (list[str]): list of files containing the interferer positions
+        interferer_files (List[str]): list of files containing the interferer positions
 
     Returns:
         dict: dictionary representation of the scene following CEC2 scene.json format

--- a/clarity/data/scene_renderer_cec1.py
+++ b/clarity/data/scene_renderer_cec1.py
@@ -298,7 +298,7 @@ class Renderer:
         outputs.append((f"{prefix}_target_anechoic.wav", target_anechoic))
 
         # Write all output files
-        for (filename, signal) in outputs:
+        for filename, signal in outputs:
             self.write_signal(filename, signal, self.sample_rate)
 
 

--- a/clarity/data/scene_renderer_cec1.py
+++ b/clarity/data/scene_renderer_cec1.py
@@ -22,7 +22,7 @@ class Renderer:
         input_path,
         output_path,
         num_channels=1,
-        fs=44100,
+        sample_rate=44100,
         ramp_duration=0.5,
         tail_duration=0.2,
         pre_duration=2.0,
@@ -32,9 +32,9 @@ class Renderer:
 
         self.input_path = input_path
         self.output_path = output_path
-        self.fs = fs
+        self.sample_rate = sample_rate
         self.ramp_duration = ramp_duration
-        self.n_tail = int(tail_duration * fs)
+        self.n_tail = int(tail_duration * sample_rate)
         self.pre_duration = pre_duration
         self.post_duration = post_duration
         self.test_nbits = test_nbits
@@ -59,7 +59,7 @@ class Renderer:
             offset_is_samples (bool): measurement units for offset (default: False)
 
         Returns:
-            ndarray: audio signal
+            np.ndarray: audio signal
         """
         try:
             wave_file = SoundFile(filename)
@@ -72,8 +72,10 @@ class Renderer:
                 f"Wav file ({filename}) was expected to have {nchannels} channels."
             )
 
-        if wave_file.samplerate != self.fs:
-            raise Exception(f"Sampling rate is not {self.fs} for filename {filename}.")
+        if wave_file.samplerate != self.sample_rate:
+            raise Exception(
+                f"Sampling rate is not {self.sample_rate} for filename {filename}."
+            )
 
         if not offset_is_samples:  # Default behaviour
             offset = int(offset * wave_file.samplerate)
@@ -84,38 +86,63 @@ class Renderer:
         x = wave_file.read(frames=nsamples)
         return x
 
-    def write_signal(self, filename, x, fs, floating_point=True):
-        """Write a signal as fixed or floating point wav file."""
+    def write_signal(
+        self,
+        filename: str,
+        signal: np.ndarray,
+        sample_rate: int,
+        floating_point: bool = True,
+    ) -> None:
+        """Write a signal as fixed or floating point wav file.
 
-        if fs != self.fs:
-            logging.warning("Sampling rate mismatch: %s with sr=%s.", filename, fs)
+        Args:
+            filename (string): Name of file to write to.
+            signal (np.ndarray): Array to write.
+            sample_rate (int): Sample Rate
+            floating_point (bool): Whether to write as subtype of floating point
+
+        Returns:
+            None: Does not return anything, writes signal to given filename.
+        """
+
+        if sample_rate != self.sample_rate:
+            logging.warning(
+                f"Sampling rate mismatch: {filename} with sample rate={sample_rate}."
+            )
             # raise ValueError("Sampling rate mismatch")
 
         if floating_point is False:
             if self.test_nbits == 16:
                 subtype = "PCM_16"
                 # If signal is float and we want int16
-                x *= 32768
-                x = x.astype(np.dtype("int16"))
-                assert np.max(x) <= 32767 and np.min(x) >= -32768
+                signal *= 32768
+                signal = signal.astype(np.dtype("int16"))
+                assert np.max(signal) <= 32767 and np.min(signal) >= -32768
             elif self.test_nbits == 24:
                 subtype = "PCM_24"
         else:
             subtype = "FLOAT"
 
-        soundfile.write(filename, x, fs, subtype=subtype)
+        soundfile.write(filename, signal, sample_rate, subtype=subtype)
 
-    def apply_ramp(self, x, dur):
-        """Apply half cosine ramp into and out of signal
+    def apply_ramp(self, signal, ramp_duration):
+        """Apply half cosine ramp into and out of signal.
 
-        dur - ramp duration in seconds
+        Args:
+            signal (np.ndarray): signal to be ramped.
+            ramp_duration (int): ramp duration in seconds.
+
+        Returns:
+            np.ndarray: Signal ramped into and out of by cosine function.
         """
-        ramp = np.cos(np.linspace(math.pi, 2 * math.pi, int(self.fs * dur)))
+        ramp = np.cos(
+            np.linspace(math.pi, 2 * math.pi, int(self.sample_rate * ramp_duration))
+        )
         ramp = (ramp + 1) / 2
-        y = np.array(x)
-        y[0 : len(ramp)] *= ramp
-        y[-len(ramp) :] *= ramp[::-1]
-        return y
+        signal_ramped = np.array(signal)
+        signal_ramped[0 : len(ramp)] *= ramp
+        signal_ramped[-len(ramp) :] *= ramp[::-1]
+        return signal_ramped
 
     def apply_brir(self, signal, brir):
         """Convolve a signal with a BRIR.
@@ -143,32 +170,46 @@ class Renderer:
         output = np.vstack([signal_l, signal_r]).T
         return output[0:output_len, :]
 
-    def compute_snr(self, target, noise, pre_samples=0, post_samples=-1):
-        """Return the SNR.
+    def compute_snr(
+        self, target: np.ndarray, noise: np.ndarray, pre_samples=0, post_samples=-1
+    ):
+        """Return the Signal Noise Ratio (SNR).
+
         Take the overlapping segment of the noise and get the speech-weighted
-        better ear SNR. (Note, SNR is a ratio -- not in dB.)
+        better ear Signal Noise Ratio. (Note, SNR is a ratio -- not in dB.)
+
+        Args:
+            target (np.ndarray): Target signal.
+            noise (np.ndarray): Noise (should be same length as target)
+
+        Returns:
+            float: signal_noise_ratio for better ear.
         """
 
-        pre_samples = int(self.fs * self.pre_duration)
-        post_samples = int(self.fs * self.post_duration)
+        pre_samples = int(self.sample_rate * self.pre_duration)
+        post_samples = int(self.sample_rate * self.post_duration)
 
         segment_target = target[pre_samples:-post_samples]
         segment_noise = noise[pre_samples:-post_samples]
-        assert len(segment_target) == len(segment_noise)
+        try:
+            assert len(segment_target) == len(segment_noise)
+        except AssertionError as e:
+            raise ValueError(
+                f"Target ({len(segment_target)}) differs in length from Noise ({len(segment_noise)})"
+            ) from e
 
         snr = better_ear_speechweighted_snr(segment_target, segment_noise)
-
         return snr
 
     def render(
         self,
-        target,
-        noise_type,
-        interferer,
-        room,
-        scene,
+        target: str,
+        noise_type: str,
+        interferer: str,
+        room: str,
+        scene: str,
         offset,
-        snr_dB,
+        snr_dB: int,
         dataset,
         pre_samples=88200,
         post_samples=44100,
@@ -184,7 +225,7 @@ class Renderer:
         target = self.read_signal(target_fn)
         target = np.pad(target, [(pre_samples, post_samples)])
 
-        interferer = self.read_signal(
+        interferer_signal = self.read_signal(
             interferer_fn, offset=offset, nsamples=len(target), offset_is_samples=True
         )
 
@@ -192,12 +233,14 @@ class Renderer:
             logging.debug("Target and interferer have different lengths")
 
         # Apply 500ms half-cosine ramp
-        interferer = self.apply_ramp(interferer, dur=self.ramp_duration)
+        interferer_signal = self.apply_ramp(
+            interferer_signal, ramp_duration=self.ramp_duration
+        )
 
         prefix = f"{self.output_path}/{scene}"
         outputs = [
             (f"{prefix}_target.wav", target),
-            (f"{prefix}_interferer.wav", interferer),
+            (f"{prefix}_interferer.wav", interferer_signal),
         ]
 
         snr_ref = None
@@ -210,7 +253,7 @@ class Renderer:
 
             # Apply the BRIRs
             target_at_ear = self.apply_brir(target, target_brir)
-            interferer_at_ear = self.apply_brir(interferer, interferer_brir)
+            interferer_at_ear = self.apply_brir(interferer_signal, interferer_brir)
 
             # Scale interferer to obtain SNR specified in scene description
             logging.info("Scaling interferer to obtain mixture SNR = %s dB.", snr_dB)
@@ -257,14 +300,16 @@ class Renderer:
 
         # Write all output files
         for (filename, signal) in outputs:
-            self.write_signal(filename, signal, self.fs)
+            self.write_signal(filename, signal, self.sample_rate)
 
 
-def check_scene_exists(scene, output_path, num_channels):
+def check_scene_exists(scene: dict, output_path: str, num_channels: int) -> bool:
     """Checks correct dataset directory for full set of pre-existing files.
 
     Args:
         scene (dict): dictionary defining the scene to be generated.
+        output_path (str): Path files should be saved to.
+        num_channels (int): Number of channels
 
     Returns:
         status: boolean value indicating whether scene signals exist

--- a/clarity/data/scene_renderer_cec1.py
+++ b/clarity/data/scene_renderer_cec1.py
@@ -1,3 +1,4 @@
+"""Scene rendering for CEC1 challenge."""
 import logging
 import math
 import os

--- a/clarity/data/utils.py
+++ b/clarity/data/utils.py
@@ -1,3 +1,4 @@
+"""Utilities for data generation."""
 import os
 import sys
 

--- a/clarity/data/utils.py
+++ b/clarity/data/utils.py
@@ -29,6 +29,8 @@ def better_ear_speechweighted_snr(target: np.ndarray, noise: np.ndarray) -> floa
         noise (np.ndarray):
 
     Returns:
+        (float)
+    Maximum Signal Noise Ratio between left and right channel.
     """
     if np.ndim(target) == 1:
         # analysis left ear and right ear for single channel target
@@ -105,7 +107,6 @@ def pad(signal: np.ndarray, length: int) -> np.ndarray:
     Returns:
         np.array:
     """
-    # FIXME : Consider encapsulating in a 'try: ... except: ...' should the assertion not be met.
     try:
         assert length >= signal.shape[0]
     except AssertionError:

--- a/tests/data/test_HOA_tools_cec2.py
+++ b/tests/data/test_HOA_tools_cec2.py
@@ -47,7 +47,7 @@ def test_centred_element_index_error(random_matrix: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
-    "i, a, b, el, expected",
+    "i, a, b, order, expected",
     [
         (1, 1, 2, 2, -0.3475073926260553),
         (1, 1, 2, -2, 0.6814353682034401),
@@ -55,22 +55,24 @@ def test_centred_element_index_error(random_matrix: np.ndarray) -> None:
     ],
 )
 def test_P(
-    i: int, a: int, b: int, el: int, random_matrix: np.ndarray, expected: float
+    i: int, a: int, b: int, order: int, random_matrix: np.ndarray, expected: float
 ) -> None:
     """Test for P() function."""
     # FixMe : how long is the list of matrices that is passed in?
-    assert P(i, a, b, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+    assert (
+        P(i, a, b, order, r=[random_matrix, random_matrix, random_matrix]) == expected
+    )
 
 
 def test_P_index_error(random_matrix: np.ndarray) -> None:
     """Test P() raises IndexError if invalid indices to r are provided."""
     # FixMe : how long is the list of matrices that is passed in?
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=1, el=1, r=[random_matrix])
+        assert P(i=1, a=5, b=1, order=1, r=[random_matrix])
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=1, el=-1, r=[random_matrix])
+        assert P(i=1, a=5, b=1, order=-1, r=[random_matrix])
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=4, el=3, r=[random_matrix])
+        assert P(i=1, a=5, b=4, order=3, r=[random_matrix])
 
 
 @pytest.mark.parametrize(

--- a/tests/data/test_HOA_tools_cec2.py
+++ b/tests/data/test_HOA_tools_cec2.py
@@ -60,7 +60,14 @@ def test_P(
     """Test for P() function."""
     # FixMe : how long is the list of matrices that is passed in?
     assert (
-        P(i, a, b, order, r=[random_matrix, random_matrix, random_matrix]) == expected
+        P(
+            i,
+            a,
+            b,
+            order,
+            rotation_matrices=[random_matrix, random_matrix, random_matrix],
+        )
+        == expected
     )
 
 
@@ -68,11 +75,11 @@ def test_P_index_error(random_matrix: np.ndarray) -> None:
     """Test P() raises IndexError if invalid indices to r are provided."""
     # FixMe : how long is the list of matrices that is passed in?
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=1, order=1, r=[random_matrix])
+        assert P(i=1, a=5, b=1, order=1, rotation_matrices=[random_matrix])
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=1, order=-1, r=[random_matrix])
+        assert P(i=1, a=5, b=1, order=-1, rotation_matrices=[random_matrix])
     with pytest.raises(IndexError):
-        assert P(i=1, a=5, b=4, order=3, r=[random_matrix])
+        assert P(i=1, a=5, b=4, order=3, rotation_matrices=[random_matrix])
 
 
 @pytest.mark.parametrize(

--- a/tests/data/test_HOA_tools_cec2.py
+++ b/tests/data/test_HOA_tools_cec2.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from clarity.data.HOA_tools_cec2 import (  # HOARotator,; ambisonic_convolve,; binaural_mixdown,; compute_band_rotation,; compute_rotation_matrix,; dB_to_gain,; dot,; smoothstep,
+from clarity.data.HOA_tools_cec2 import (  # HOARotator,; ambisonic_convolve,; binaural_mixdown,; compute_band_rotation,; compute_rotation_matrix,;  dot,; dot,
     P,
     U,
     V,
@@ -10,9 +10,11 @@ from clarity.data.HOA_tools_cec2 import (  # HOARotator,; ambisonic_convolve,; b
     centred_element,
     compute_rms,
     compute_UVW_coefficients,
+    dB_to_gain,
     equalise_rms_levels,
     rotation_control_vector,
     rotation_vector,
+    smoothstep,
 )
 
 
@@ -22,7 +24,7 @@ def test_compute_rotation_matrix() -> None:
 
 
 @pytest.mark.parametrize(
-    "i, j, expected",
+    "row, col, expected",
     [
         (1, 1, 0.8840922122960315),
         (45, 54, 0.2378095805520779),
@@ -30,18 +32,18 @@ def test_compute_rotation_matrix() -> None:
     ],
 )
 def test_centred_element(
-    random_matrix: np.ndarray, i: int, j: int, expected: float
+    random_matrix: np.ndarray, row: int, col: int, expected: float
 ) -> None:
     """Test for centered_element() function."""
-    assert centred_element(random_matrix, i, j) == expected
+    assert centred_element(random_matrix, row, col) == expected
 
 
 def test_centred_element_index_error(random_matrix: np.ndarray) -> None:
     """Test centered_element() raises an IndexError if centering is outside of matrix dimensions."""
     with pytest.raises(IndexError):
-        centred_element(random_matrix, i=101, j=2)
+        centred_element(random_matrix, row=101, col=2)
     with pytest.raises(IndexError):
-        centred_element(random_matrix, i=1, j=102)
+        centred_element(random_matrix, row=1, col=102)
 
 
 @pytest.mark.parametrize(
@@ -72,20 +74,30 @@ def test_P_index_error(random_matrix: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
-    "m, n, el, expected",
+    "degree, n, order, expected",
     [
         (1, 2, 2, 0.8066335578037782),
         (1, 2, -2, 0.647932971103906),
         (1, 2, 2, 0.504340149676519),
     ],
 )
-def test_U(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
-    """Test for XX function."""
-    assert U(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+def test_U(
+    degree: int, n: int, order: int, random_matrix: np.ndarray, expected: float
+) -> None:
+    """Test for U function."""
+    assert (
+        U(
+            degree,
+            n,
+            order,
+            rotation_matrices=[random_matrix, random_matrix, random_matrix],
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
-    "m, n, el, expected",
+    "degree, n, order, expected",
     [
         (0, 2, 2, -0.02607000059684761),
         (1, 2, 2, -0.8041211269599031),
@@ -93,26 +105,46 @@ def test_U(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) 
         (-1, 2, -2, 0.5668224726503112),
     ],
 )
-def test_V(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
+def test_V(
+    degree: int, n: int, order: int, random_matrix: np.ndarray, expected: float
+) -> None:
     """Test for V() function."""
-    assert V(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+    assert (
+        V(
+            degree,
+            n,
+            order,
+            rotation_matrices=[random_matrix, random_matrix, random_matrix],
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
-    "m, n, el, expected",
+    "degree, n, order, expected",
     [
         (0, 2, 2, 0.0),
         (1, 2, 2, -0.18322112315448064),
         (-1, 2, 2, -0.3501066433176404),
     ],
 )
-def test_W(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) -> None:
+def test_W(
+    degree: int, n: int, order: int, random_matrix: np.ndarray, expected: float
+) -> None:
     """Test for W() function."""
-    assert W(m, n, el, r=[random_matrix, random_matrix, random_matrix]) == expected
+    assert (
+        W(
+            degree,
+            n,
+            order,
+            rotation_matrices=[random_matrix, random_matrix, random_matrix],
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
-    "m, n, el, expected",
+    "degree, n, order, expected",
     [
         (0, 2, 2, (0.5773502691896257, -0.28867513459481287, -0.0)),
         (1, 2, 2, (0.5, 0.3535533905932738, -0.0)),
@@ -120,15 +152,17 @@ def test_W(m: int, n: int, el: int, random_matrix: np.ndarray, expected: float) 
         # (-1, 2, 1, (-0.0, np.nan, -0.0)),  # FixMe : This is probably going to cause problems how to capture?
     ],
 )
-def test_compute_UVW_coefficients(m: int, n: int, el: int, expected: float) -> None:
+def test_compute_UVW_coefficients(
+    degree: int, n: int, order: int, expected: float
+) -> None:
     """Test for computer_UVW_coefficients() function."""
-    assert compute_UVW_coefficients(m, n, el) == expected
+    assert compute_UVW_coefficients(degree, n, order) == expected
 
 
 def test_compute_UVW_coefficients_zero_division_error() -> None:
     """Test computer_UVW_coefficients() raises ZeroDivisionError"""
     with pytest.raises(ZeroDivisionError):
-        compute_UVW_coefficients(m=-1, n=2, el=-2)
+        compute_UVW_coefficients(degree=-1, n=2, order=-2)
 
 
 # FixMe : Not yet working, I don't understand how to get the `output` passed in correctly
@@ -152,7 +186,7 @@ def test_compute_UVW_coefficients_zero_division_error() -> None:
 #     ],
 # )
 # def test_dot(A: np.ndarray, B: np.ndarray, expected: np.ndarray) -> None:
-#     """Test for XX function."""
+#     """Test for dot() function."""
 #     np.testing.assert_array_equal(dot(A, B), expected)
 
 
@@ -161,6 +195,7 @@ def test_HOARotator() -> None:
     assert True
 
 
+# FixMe : need examples of hrir_metadata dictionary to be able to write a tests for this
 def test_binaural_mixdown() -> None:
     """Test for binaural_mixdown() function."""
     assert True
@@ -204,14 +239,52 @@ def test_equalise_rms_levels(random_matrix: np.ndarray) -> None:
     assert equalise_rms_levels(inputs=[random_matrix, random_matrix])
 
 
-def test_dB_to_gain() -> None:
+@pytest.mark.parametrize(
+    "db, gain", [(10, 3.1622776601683795), (20, 10.0), (0.045, 1.0051942600951387)]
+)
+def test_dB_to_gain(db: float, gain: float) -> None:
     """Test for XX function."""
-    assert True
+    assert dB_to_gain(db) == gain
 
 
-def test_smoothstep() -> None:
-    """Test for XX function."""
-    assert True
+@pytest.mark.parametrize(
+    "x, x_min, x_max, N, expected",
+    [
+        (
+            np.asarray([100, 200, 300, 400]),
+            10,
+            300,
+            1,
+            np.asarray([0.229161, 0.725286, 1.0, 1.0]),
+        ),
+        (
+            np.asarray([10, 200, 300, 4000]),
+            10,
+            300,
+            1,
+            np.asarray([0.0, 0.725286, 1.0, 1.0]),
+        ),
+        (
+            np.asarray([10, -200, 300, 4000]),
+            -200,
+            300,
+            1,
+            np.asarray([0.381024, 0.0, 1.0, 1.0]),
+        ),
+        (
+            np.asarray([10, -50, 300, 4000]),
+            -200,
+            300,
+            1,
+            np.asarray([0.381024, 0.216, 1.0, 1.0]),
+        ),
+    ],
+)
+def test_smoothstep(
+    x: np.ndarray, x_min: float, x_max: float, N: int, expected
+) -> None:
+    """Test for smoothstep() function."""
+    np.testing.assert_array_almost_equal(smoothstep(x, x_min, x_max, N), expected)
 
 
 @pytest.mark.parametrize(
@@ -294,7 +367,6 @@ def test_rotation_vector(
         rotation_vector(start_angle, end_angle, signal_length, start_idx, end_idx),
         expected,
     )
-    assert True
 
 
 def test_rotation_vector_floating_point_error() -> None:


### PR DESCRIPTION
Further work on PEP8 nomenclature, starting to address the `clarity/data/` modules.

* PEP8 nomenclature for some HOA_tools_cec2.py and improving some tests. Couldn't work out what some variables are though, happy to take feedback in this PR and update.
* Renaming a few variables and tidying up a bit in cec1.
* Docstrings in demo_data.py
* Also adding check_yaml to .pre-commit-config.yaml
* Docstrings and typing for scene_builder_cec2.py