### PR TITLE
Speeded up the two slowest tests

### DIFF
--- a/tests/recipes/cad1/task1/test_evaluate.py
+++ b/tests/recipes/cad1/task1/test_evaluate.py
@@ -101,14 +101,14 @@ def test_make_song_listener_list():
                 }
             },
             {
-                "left_drums": 0.107854176,
-                "right_drums": 0.104024261,
-                "left_bass": 0.111090873,
-                "right_bass": 0.108046217,
-                "left_other": 0.111885722,
-                "right_other": 0.110098967,
-                "left_vocals": 0.103490312,
-                "right_vocals": 0.108655100,
+                "left_drums": 0.149880148,
+                "right_drums": 0.143182857,
+                "left_bass": 0.140449345,
+                "right_bass": 0.181374074,
+                "left_other": 0.132401105,
+                "right_other": 0.164211137,
+                "left_vocals": 0.121260627,
+                "right_vocals": 0.126605279,
             },
         )
     ],
@@ -139,10 +139,11 @@ def test_evaluate_song_listener(
         )
         enh_file.parent.mkdir(exist_ok=True, parents=True)
 
+        # Using very short 100 ms signals to speed up the test
         wavfile.write(
             enh_file,
             44100,
-            np.random.uniform(-1, 1, 44100 * 5).astype(np.float32) * 32768,
+            np.random.uniform(-1, 1, 4410).astype(np.float32) * 32768,
         )
 
     for instrument in instruments:
@@ -152,7 +153,7 @@ def test_evaluate_song_listener(
         wavfile.write(
             ref_file,
             44100,
-            np.random.uniform(-1, 1, (44100 * 5, 2)).astype(np.float32) * 32768,
+            np.random.uniform(-1, 1, (4410, 2)).astype(np.float32) * 32768,
         )
 
     # Call the function
@@ -168,12 +169,12 @@ def test_evaluate_song_listener(
     # Check the outputs
     # Combined score
     assert isinstance(combined_score, float)
-    assert combined_score == pytest.approx(0.1081432040, rel=1e-7)
+    assert combined_score == pytest.approx(0.144920571533222, rel=1e-7)
 
     # Per instrument score
     assert isinstance(per_instrument_score, dict)
-    for instrument in list(expected_results.keys()):
-        assert instrument in per_instrument_score.keys()
+    for instrument in expected_results:
+        assert instrument in per_instrument_score
         assert isinstance(per_instrument_score[instrument], float)
         assert per_instrument_score[instrument] == pytest.approx(
             expected_results[instrument], rel=1e-7

--- a/tests/regression/_regtest_outputs/test_full_CEC2_pipeline.test_full_cec2_pipeline.out
+++ b/tests/regression/_regtest_outputs/test_full_CEC2_pipeline.test_full_cec2_pipeline.out
@@ -1,1 +1,1 @@
-Enhanced audio HASPI score is 0.2994140
+Enhanced audio HASPI score is 0.7491526

--- a/tests/regression/_regtest_outputs/test_full_CEC2_pipeline.test_full_cec2_pipeline.out
+++ b/tests/regression/_regtest_outputs/test_full_CEC2_pipeline.test_full_cec2_pipeline.out
@@ -1,1 +1,1 @@
-Enhanced audio HASPI score is 0.7491526
+Enhanced audio HASPI score is 0.7491529

--- a/tests/regression/test_full_CEC2_pipeline.py
+++ b/tests/regression/test_full_CEC2_pipeline.py
@@ -28,13 +28,13 @@ SCENE = {
     "dataset": "demo",
     "room": "R06001",
     "scene": "S06001",
-    "target": {"name": "T010_G0N_02468", "time_start": 37837, "time_end": 115894},
-    "duration": 150000,
+    "target": {"name": "T010_G0N_02468", "time_start": 0, "time_end": 115894},
+    "duration": 8820,
     "interferers": [
         {
             "position": 1,
             "time_start": 0,
-            "time_end": 150000,
+            "time_end": 8820,
             "type": "noise",
             "name": "CIN_fan_014.wav",
             "offset": 5376,
@@ -42,7 +42,7 @@ SCENE = {
         {
             "position": 2,
             "time_start": 0,
-            "time_end": 150000,
+            "time_end": 8820,
             "type": "speech",
             "name": "som_04766_05.wav",
             "offset": 40000,
@@ -50,7 +50,7 @@ SCENE = {
         {
             "position": 3,
             "time_start": 0,
-            "time_end": 150000,
+            "time_end": 8820,
             "type": "music",
             "name": "1111967.low.mp3",
             "offset": 842553,
@@ -59,8 +59,8 @@ SCENE = {
     "SNR": 0.0,
     "listener": {
         "rotation": [
-            {"sample": 116192.9795, "angle": 52.3628},
-            {"sample": 124829.9795, "angle": 38.5256},
+            {"sample": 100, "angle": 52.3628},
+            {"sample": 400, "angle": 38.5256},
         ],
         "hrir_filename": ["VP_N6-ED", "VP_N6-BTE_fr"],
     },
@@ -119,10 +119,10 @@ def test_full_cec2_pipeline(
     reference = reference.astype(float) / 32768.0
     signal = signal.astype(float) / 32768.0
 
-    # Truncate to just over 2 seconds - i.e. just use part of the signals
+    # Truncate to 200 ms - i.e. just use part of the signals
     # to speed up the HASPI calculation a little
-    signal = signal[:100000, :]
-    reference = reference[:100000, :]
+    signal = signal[:8820, :]
+    reference = reference[:8820, :]
 
     # The data below doesn't really need to be meaningful.
     # The purpose of the test is not to see if the haspi score is reasonable


### PR DESCRIPTION
tests/regression/test_full_CEC2_pipeline.py::test_full_cec2_pipeline 14.91s -> 1.64s
tests/recipes/cad1/task1/test_evaluate.py::test_evaluate_song_listener 27.36s -> 0.7s