### PR TITLE
Restricting Pytorch to version < 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
   scikit-learn>=1.0.2
   scipy>=1.7.3
   SoundFile>=0.10.3.post1
-  torch
+  torch<2.0
   torchaudio
   tqdm>=4.62.3
   typing_extensions


### PR DESCRIPTION
Pytorch 2.0 breaks some tests.
Restrict the version until we are sure what are the main differences between Pytorch 1 and 2 that affect the current tests.
