### PR TITLE
105-inconsistent-logic-with-parameter-shift-in-evaluatorhaspiebcenterfreq

### DIFF
--- a/clarity/evaluator/haspi/eb.py
+++ b/clarity/evaluator/haspi/eb.py
@@ -29,7 +29,7 @@ def ear_model(
     level1,
     nchan=32,
     m_delay=1,
-    shift=0.02,
+    shift=None,
 ):
     """
     Function that implements a cochlear model that includes the middle ear,
@@ -357,9 +357,6 @@ def center_frequency(
     Translated from MATLAB to Python by Zuzanna Podwinska, March 2022.
     """
 
-    # In the Matlab code, the loop below never evaluates
-    # (but the current code was trained with this bug)
-    shift = None  # This is to keep consistency with MATLAB code
     if shift is not None:
         k = 1
         A = 165.4  # pylint: disable=invalid-name

--- a/clarity/evaluator/haspi/haspi.py
+++ b/clarity/evaluator/haspi/haspi.py
@@ -68,6 +68,8 @@ def haspi_v2(  # pylint: disable=too-many-arguments too-many-locals
         hearing_loss,
         itype,
         level1,
+        # shift=0.02 # Original HASPI code had a bug such that this shift was not used
+        shift=None,
     )
 
     # Envelope modulation features


### PR DESCRIPTION
The bug in the original HASPI code was being preserved by enforcing it in the low level centre_freq function. This has been changed so that centre_freq can now work as expected and the bug has been lifted up to the top level HASPI function where it can be clearly seen.