### PR TITLE
Align black and ruff target-version to py38 with rest of package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ omit = [
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
 
 (
@@ -205,7 +205,7 @@ exclude = [
 ]
 # per-file-ignores = []
 line-length = 88
-target-version = "py37"
+target-version = "py38"
 select = ["B", "E", "F", "I001", "W"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "R", "S", "W", "U"]


### PR DESCRIPTION
I missed these out too and only just noticed.