### PR TITLE
293-refactor-signal-read-and-write

### DIFF
--- a/clarity/data/scene_renderer_cec1.py
+++ b/clarity/data/scene_renderer_cec1.py
@@ -5,10 +5,9 @@ from pathlib import Path
 
 import numpy as np
 from scipy.signal import convolve
-from soundfile import SoundFile
 
 from clarity.data.utils import better_ear_speechweighted_snr, pad, sum_signals
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 
 class Renderer:
@@ -46,42 +45,6 @@ class Renderer:
             # ... as above plus N hearing aid input channels plus 'channel 0'
             # (the eardrum signal). e.g. num_channel = 2  => channels [1, 2, 0]
             self.channels = list(range(1, num_channels + 1)) + [0]
-
-    def read_signal(
-        self, filename, offset=0, nsamples=-1, nchannels=0, offset_is_samples=False
-    ):
-        """Read a wavefile and return as numpy array of floats.
-
-        Args:
-            filename (string): Name of file to read
-            offset (int, optional): Offset in samples or seconds from start.
-                Defaults to 0.
-            nchannels: expected number of channel (default: 0 = any number OK)
-            offset_is_samples (bool): measurement units for offset (default: False)
-
-        Returns:
-            np.ndarray: audio signal
-        """
-        wave_file = SoundFile(filename)
-
-        if nchannels not in (0, wave_file.channels):
-            raise ValueError(
-                f"Wav file ({filename}) was expected to have {nchannels} channels."
-            )
-
-        if wave_file.samplerate != self.sample_rate:
-            raise ValueError(
-                f"Sampling rate is not {self.sample_rate} for filename {filename}."
-            )
-
-        if not offset_is_samples:  # Default behaviour
-            offset = int(offset * wave_file.samplerate)
-
-        if offset != 0:
-            wave_file.seek(offset)
-
-        x = wave_file.read(frames=nsamples)
-        return x
 
     def apply_ramp(self, signal, ramp_duration):
         """Apply half cosine ramp into and out of signal.
@@ -180,11 +143,18 @@ class Renderer:
             f"{self.input_path}/{dataset}/interferers/{noise_type}/{interferer_id}.wav"
         )
 
-        target = self.read_signal(target_fn)
+        target = read_signal(
+            target_fn, sample_rate=self.sample_rate, allow_resample=False
+        )
         target = np.pad(target, [(pre_samples, post_samples)])
 
-        interferer_signal = self.read_signal(
-            interferer_fn, offset=offset, nsamples=len(target), offset_is_samples=True
+        interferer_signal = read_signal(
+            interferer_fn,
+            sample_rate=self.sample_rate,
+            offset=offset,
+            n_samples=len(target),
+            offset_is_samples=True,
+            allow_resample=False,
         )
 
         if len(interferer_signal) != len(target):
@@ -207,8 +177,12 @@ class Renderer:
             # Load scene BRIRs
             target_brir_fn = f"{brir_stem}_t_CH{channel}.wav"
             interferer_brir_fn = f"{brir_stem}_i1_CH{channel}.wav"
-            target_brir = self.read_signal(target_brir_fn)
-            interferer_brir = self.read_signal(interferer_brir_fn)
+            target_brir = read_signal(
+                target_brir_fn, sample_rate=self.sample_rate, allow_resample=False
+            )
+            interferer_brir = read_signal(
+                interferer_brir_fn, sample_rate=self.sample_rate, allow_resample=False
+            )
 
             # Apply the BRIRs
             target_at_ear = self.apply_brir(target, target_brir)
@@ -244,13 +218,17 @@ class Renderer:
 
         if self.channels == []:
             target_brir_fn = f"{brir_stem}_t_CH0.wav"
-            target_brir = self.read_signal(target_brir_fn)
+            target_brir = read_signal(
+                target_brir_fn, sample_rate=self.sample_rate, allow_resample=False
+            )
 
         # Construct the anechoic target reference signal
         anechoic_brir_fn = (
             f"{anechoic_brir_stem}_t_CH1.wav"  # CH1 used for the anechoic signal
         )
-        anechoic_brir = self.read_signal(anechoic_brir_fn)
+        anechoic_brir = read_signal(
+            anechoic_brir_fn, sample_rate=self.sample_rate, allow_resample=False
+        )
         # Padding the anechoic brir very inefficient but keeps it simple
         anechoic_brir_pad = pad(anechoic_brir, len(target_brir))
         target_anechoic = self.apply_brir(target, anechoic_brir_pad)

--- a/clarity/data/scene_renderer_cec1.py
+++ b/clarity/data/scene_renderer_cec1.py
@@ -4,11 +4,11 @@ import math
 from pathlib import Path
 
 import numpy as np
-import soundfile
 from scipy.signal import convolve
 from soundfile import SoundFile
 
 from clarity.data.utils import better_ear_speechweighted_snr, pad, sum_signals
+from clarity.utils.file_io import write_signal
 
 
 class Renderer:
@@ -82,45 +82,6 @@ class Renderer:
 
         x = wave_file.read(frames=nsamples)
         return x
-
-    def write_signal(
-        self,
-        filename: str,
-        signal: np.ndarray,
-        sample_rate: int,
-        floating_point: bool = True,
-    ) -> None:
-        """Write a signal as fixed or floating point wav file.
-
-        Args:
-            filename (string): Name of file to write to.
-            signal (np.ndarray): Array to write.
-            sample_rate (int): Sample Rate
-            floating_point (bool): Whether to write as subtype of floating point
-
-        Returns:
-            None: Does not return anything, writes signal to given filename.
-        """
-
-        if sample_rate != self.sample_rate:
-            logging.warning(
-                f"Sampling rate mismatch: {filename} with sample rate={sample_rate}."
-            )
-            # raise ValueError("Sampling rate mismatch")
-
-        if floating_point is False:
-            if self.test_nbits == 16:
-                subtype = "PCM_16"
-                # If signal is float and we want int16
-                signal *= 32768
-                signal = signal.astype(np.dtype("int16"))
-                assert np.max(signal) <= 32767 and np.min(signal) >= -32768
-            elif self.test_nbits == 24:
-                subtype = "PCM_24"
-        else:
-            subtype = "FLOAT"
-
-        soundfile.write(filename, signal, sample_rate, subtype=subtype)
 
     def apply_ramp(self, signal, ramp_duration):
         """Apply half cosine ramp into and out of signal.
@@ -298,7 +259,7 @@ class Renderer:
 
         # Write all output files
         for filename, signal in outputs:
-            self.write_signal(filename, signal, self.sample_rate)
+            write_signal(filename, signal, self.sample_rate, strict=True)
 
 
 def check_scene_exists(scene: dict, output_path: str, num_channels: int) -> bool:

--- a/clarity/enhancer/gha/gha_interface.py
+++ b/clarity/enhancer/gha/gha_interface.py
@@ -9,10 +9,9 @@ from pathlib import Path
 
 import numpy as np
 from jinja2 import Environment, FileSystemLoader
-from soundfile import SoundFile
 
 from clarity.enhancer.gha.gha_utils import format_gaintable, get_gaintable
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 
 class GHAHearingAid:
@@ -174,7 +173,9 @@ class GHAHearingAid:
         os.remove(cfg_filename)
 
         # Check output signal has energy in every channel
-        sig = self.read_signal(outfile_name)
+        sig = read_signal(
+            outfile_name, sample_rate=self.sample_rate, allow_resample=False
+        )
 
         if len(np.shape(sig)) == 1:
             sig = np.expand_dims(sig, axis=1)
@@ -186,50 +187,6 @@ class GHAHearingAid:
         write_signal(outfile_name, sig, self.sample_rate, floating_point=True)
 
         logging.info("OpenMHA processing complete")
-
-    # TODO: MARKED FOR DEDUPLICATION
-    # Mirrors functionality that already exists in msbg_utils
-    def read_signal(
-        self,
-        filename: str | Path,
-        offset: int = 0,
-        nsamples: int = -1,
-        nchannels: int = 0,
-        offset_is_samples: bool = False,
-    ):
-        """Read a wavefile and return as numpy array of floats.
-
-        Args:
-            filename (string): Name of file to read
-            offset (int, optional): Offset in samples or seconds (from start).
-                Defaults to 0.
-            nchannels: expected number of channel (default: 0 = any number OK)
-            offset_is_samples (bool): measurement units for offset (default: False)
-        Returns:
-            ndarray: audio signal
-        """
-
-        wave_file = SoundFile(filename)
-
-        if nchannels not in (0, wave_file.channels):
-            raise ValueError(
-                f"Wav file ({filename}) was expected to have {nchannels} channels."
-            )
-
-        if wave_file.samplerate != self.sample_rate:
-            raise ValueError(
-                f"Sampling rate is not {self.sample_rate} for filename {filename}."
-            )
-
-        if not offset_is_samples:  # Default behaviour
-            offset = int(offset * wave_file.samplerate)
-
-        if offset != 0:
-            wave_file.seek(offset)
-
-        x = wave_file.read(frames=nsamples)
-
-        return x
 
     def create_HA_inputs(self, infile_names: list[str], merged_filename: str) -> None:
         """Create input signal for baseline hearing aids.
@@ -248,8 +205,12 @@ class GHAHearingAid:
         if (infile_names[0][-5] != "1") or (infile_names[2][-5] != "3"):
             raise ValueError("HA-input signal error: channel mismatch!")
 
-        signal_CH1 = self.read_signal(infile_names[0])
-        signal_CH3 = self.read_signal(infile_names[2])
+        signal_CH1 = read_signal(
+            infile_names[0], sample_rate=self.sample_rate, allow_resample=False
+        )
+        signal_CH3 = read_signal(
+            infile_names[2], sample_rate=self.sample_rate, allow_resample=False
+        )
 
         merged_signal = np.zeros((len(signal_CH1), 4))
 

--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -10,7 +10,6 @@ from typing import Final, TypedDict
 import numpy as np
 import scipy
 import scipy.signal
-import soundfile
 from numpy import float64, ndarray
 from soundfile import SoundFile
 
@@ -566,45 +565,3 @@ def read_signal(
         )
 
     return signal
-
-
-def write_signal(
-    filename: str | Path,
-    signal: ndarray,
-    sample_rate: float,
-    floating_point: bool = True,
-    strict: bool = False,
-) -> None:
-    """Write a signal as fixed or floating point wav file.
-
-    NB: setting 'strict' to True will raise error on overflow. This would be
-    a more natural default but it would break existing code that did not
-    check for overflow.
-
-    Args:
-        filename (str|Path): name of file in to write to.
-        signal (ndarray): signal to write.
-        sample_rate (float): sampling frequency.
-        floating_point (bool): write as floating point else an ints (default: True).
-        strict (bool): raise error if signal out of range for int16 (default: False).
-    """
-
-    if sample_rate != MSBG_FS:
-        logging.warning(
-            f"Sampling rate mismatch: {filename} with "
-            f"sample frequency = {sample_rate}."
-        )
-        # raise ValueError("Sampling rate mismatch")
-
-    if floating_point is False:
-        subtype = "PCM_16"
-        # Signal is float and we want to convert to int16
-        # *NB* Not  *= in next line as we need to make a copy
-        signal = signal * 32768
-        if strict and (np.max(signal) > 32767 or np.min(signal) < -32768):
-            raise ValueError("Signal out of range -1.0 to 1.0")
-        signal = signal.astype(np.dtype("int16"))
-    else:
-        subtype = "FLOAT"
-
-    soundfile.write(filename, signal, sample_rate, subtype=subtype)

--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -524,7 +524,7 @@ def pad(signal: ndarray, length: int) -> ndarray:
     )
 
 
-def read_signal(
+def read_signal_x(
     filename: str | Path,
     offset: int = 0,
     nsamples: int = -1,

--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -10,8 +10,7 @@ from typing import Final, TypedDict
 import numpy as np
 import scipy
 import scipy.signal
-from numpy import float64, ndarray
-from soundfile import SoundFile
+from numpy import ndarray
 
 # measure rms parameters
 WIN_SECS: Final = 0.01
@@ -355,10 +354,10 @@ def gen_eh2008_speech_noise(
 
 def generate_key_percent(
     signal: ndarray,
-    threshold_db: float64,
+    threshold_db: float,
     window_length: int,
     percent_to_track: float | None = None,
-) -> tuple[ndarray, float64]:
+) -> tuple[ndarray, float]:
     """Generate key percent.
     Locates frames above some energy threshold or tracks a certain percentage
     of frames. To track a certain percentage of frames in order to get measure
@@ -375,7 +374,7 @@ def generate_key_percent(
         ValueError: percent_to_track is set too high.
 
     Returns:
-        (tuple): containig
+        (tuple): containing
         - key (ndarray): The key array of indices of samples used in rms calculation.
         - used_threshold_db (float): Root Mean Squared threshold.
 
@@ -522,46 +521,3 @@ def pad(signal: ndarray, length: int) -> ndarray:
     return np.pad(
         signal, [(0, length - signal.shape[0])] + [(0, 0)] * (len(signal.shape) - 1)
     )
-
-
-def read_signal_x(
-    filename: str | Path,
-    offset: int = 0,
-    nsamples: int = -1,
-    nchannels: int = 0,
-    offset_is_samples: bool = False,
-) -> ndarray:
-    """Read a wavefile and return as numpy array of floats.
-
-    Args:
-        filename (str|Path): Name of file to read
-        offset (int, optional): Offset in samples or seconds (from start). Default is 0.
-        nsamples (int): Number of samples.
-        nchannels (int): expected number of channel (default: 0 = any number OK)
-        offset_is_samples (bool): measurement units for offset (default: False)
-
-    Returns:
-        np.ndarray: audio signal
-    """
-
-    wave_file = SoundFile(filename)
-
-    if nchannels not in (0, wave_file.channels):
-        raise ValueError(
-            f"Wav file ({filename}) was expected to have {nchannels} channels."
-        )
-
-    if not offset_is_samples:  # Default behaviour
-        offset = int(offset * wave_file.samplerate)
-
-    if offset != 0:
-        wave_file.seek(offset)
-
-    signal = wave_file.read(frames=nsamples)
-
-    if wave_file.samplerate != MSBG_FS:
-        signal = scipy.signal.resample(
-            signal, int(MSBG_FS * signal.shape[0] / wave_file.samplerate)
-        )
-
-    return signal

--- a/clarity/utils/file_io.py
+++ b/clarity/utils/file_io.py
@@ -1,5 +1,12 @@
 """File I/O functions for jsonl files."""
+from __future__ import annotations
+
 import json
+from pathlib import Path
+
+import numpy as np
+import soundfile
+from numpy import ndarray
 
 
 def read_jsonl(filename: str) -> list:
@@ -14,3 +21,38 @@ def write_jsonl(filename: str, records: list) -> None:
     with open(filename, "a", encoding="utf-8") as fp:
         for record in records:
             fp.write(json.dumps(record) + "\n")
+
+
+def write_signal(
+    filename: str | Path,
+    signal: ndarray,
+    sample_rate: float,
+    floating_point: bool = True,
+    strict: bool = False,
+) -> None:
+    """Write a signal as fixed or floating point wav file.
+
+    NB: setting 'strict' to True will raise error on overflow. This would be
+    a more natural default but it would break existing code that did not
+    check for overflow.
+
+    Args:
+        filename (str|Path): name of file in to write to.
+        signal (ndarray): signal to write.
+        sample_rate (float): sampling frequency.
+        floating_point (bool): write as floating point else an ints (default: True).
+        strict (bool): raise error if signal out of range for int16 (default: False).
+    """
+
+    if floating_point is False:
+        subtype = "PCM_16"
+        # Signal is float and we want to convert to int16
+        # *NB* Not  *= in next line as we need to make a copy
+        signal = signal * 32768
+        if strict and (np.max(signal) > 32767 or np.min(signal) < -32768):
+            raise ValueError("Signal out of range -1.0 to 1.0")
+        signal = signal.astype(np.dtype("int16"))
+    else:
+        subtype = "FLOAT"
+
+    soundfile.write(filename, signal, sample_rate, subtype=subtype)

--- a/clarity/utils/file_io.py
+++ b/clarity/utils/file_io.py
@@ -1,4 +1,4 @@
-"""File I/O functions for jsonl files."""
+"""File I/O functions."""
 from __future__ import annotations
 
 import json
@@ -9,6 +9,8 @@ import scipy.signal
 import soundfile
 from numpy import ndarray
 from soundfile import SoundFile
+
+# Function for reading and writing jsonl files
 
 
 def read_jsonl(filename: str) -> list:
@@ -25,6 +27,22 @@ def write_jsonl(filename: str, records: list) -> None:
             fp.write(json.dumps(record) + "\n")
 
 
+# Functions for reading and writing audio signals.
+#
+# - Signals are passed and returns as numpy arrays of floats of shape
+#   (n_samples, n_channels). Mono signals can be passed as (n_samples, 1)
+#   but are returned as (n_samples,) which is more convenient for most purposes.
+#   Floating point and 16 bit integer file formats are supported.
+# - Signals are assumed to be in the range [-1.0 to 1.0) and will be scaled to
+#   and from -32768 to 32767 when writing to or reading from 16 bit files.
+#   On writing to 16 bit files, overflow can be set to silently wrap or to raise
+#   an error.
+# - Any sample rate can be used for writing and floating points values are
+#   rounded to integers. For reading, the 'expected sample rate' is supplied and
+#   the file is resample if necessary or can be set to throw an error. Again,
+#   this is more convenient for most purposes.
+
+
 def write_signal(
     filename: str | Path,
     signal: ndarray,
@@ -33,6 +51,13 @@ def write_signal(
     strict: bool = False,
 ) -> None:
     """Write a signal as fixed or floating point wav file.
+
+    Signals are passed as numpy arrays of floats of shape (n_samples, n_channels)
+    for n_channels >= 1 or (n_samples,) for n_channels = 1.
+
+    Signals are floating point in the range [-1.0 to 1.0) but can be written
+    as wav file with either 16 bit integers or floating point. In the former,
+    the signals are scaled to map to the range -32768 to 32767.
 
     NB: setting 'strict' to True will raise error on overflow. This would be
     a more natural default but it would break existing code that did not
@@ -62,21 +87,40 @@ def write_signal(
 
 def read_signal(
     filename: str | Path,
-    sample_rate: float = 0,
+    sample_rate: float = 0.0,
     offset: int | float = 0,  # offset can be in samples or seconds
     n_samples: int = -1,
     n_channels: int = 0,
     offset_is_samples: bool = False,
     allow_resample: bool = True,
 ) -> ndarray:
-    """Read a wavefile and return as numpy array of floats.
+    """Read a wav format audio file and return as numpy array of floats.
+
+    The returned value will be a numpy array of floats of shape (n_samples,
+    n_channels) for n_channels >= 2, and shape (n_samples,) for n_channels = 1.
+
+    If n_samples is set to a value other than -1, the specified number of samples
+    will be read, or until the end of the file. An 'offset' can be set to start
+    reading from a specified sample or time (in seconds).
+
+    The expected number of channels can be specified. If the file has a different
+    number of channels, an error will be raised.
+
+    The expected sample rate can be specified. If the file has a different sample
+    the file will be resampled to the expected sample rate, unless
+    'allow_resample' is set to False, in which case an error will be raised.
 
     Args:
         filename (str|Path): Name of file to read
-        offset (int, optional): Offset in samples or seconds (from start). Default is 0.
-        nsamples (int): Number of samples.
-        nchannels (int): expected number of channel (default: 0 = any number OK)
-        offset_is_samples (bool): measurement units for offset (default: False)
+        sample_rate (float): The expected sample rate (default: 0.0 = any rate OK)
+        offset (int, optional): Offset in samples or seconds (from start).
+            Default is 0.
+        n_samples (int): Number of samples.
+        n_channels (int): expected number of channel (default: 0 = any number OK)
+        offset_is_samples (bool): is offset measured in samples, (True) or
+            seconds (False) (default: False)
+        allow_resample (bool): allow resampling if sample rate is different
+            from expected rate. Else raise error (default: True)
 
     Returns:
         np.ndarray: audio signal

--- a/clarity/utils/file_io.py
+++ b/clarity/utils/file_io.py
@@ -5,10 +5,11 @@ import json
 from pathlib import Path
 
 import numpy as np
-import scipy.signal
 import soundfile
 from numpy import ndarray
 from soundfile import SoundFile
+
+from clarity.utils.signal_processing import resample
 
 # Function for reading and writing jsonl files
 
@@ -143,9 +144,7 @@ def read_signal(
 
     if sample_rate not in (0, wave_file.samplerate):
         if allow_resample:
-            signal = scipy.signal.resample(
-                signal, int(sample_rate * signal.shape[0] / wave_file.samplerate)
-            )
+            signal = resample(signal, wave_file.samplerate, sample_rate)
         else:
             raise ValueError(
                 f"Sample rate of {wave_file.samplerate} "

--- a/clarity/utils/signal_processing.py
+++ b/clarity/utils/signal_processing.py
@@ -46,6 +46,11 @@ def normalize_signal(signal: ndarray) -> tuple[ndarray, ndarray]:
 def resample(signal: ndarray, sample_rate: float, new_sample_rate: float) -> ndarray:
     """Resample a signal to a new sample rate.
 
+    This is a sipmle wrapper around scipy.signal.resample. with the resampling
+    expressed in terms of sampling rates rather than desired number of samples.
+    It also ensures that for multichannel signals, resampling is in the time
+    domain, i.e. down the columns.
+
     Args:
         signal: The signal to be resampled.
         sample_rate: The original sample rate.

--- a/clarity/utils/signal_processing.py
+++ b/clarity/utils/signal_processing.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import numpy as np
+import scipy
+from numpy import ndarray
 
 
-def compute_rms(signal: np.ndarray) -> float:
+def compute_rms(signal: ndarray) -> float:
     """Compute RMS of signal
 
     Args:
@@ -17,19 +19,19 @@ def compute_rms(signal: np.ndarray) -> float:
     return np.sqrt(np.mean(np.square(signal)))
 
 
-def denormalize_signals(sources: np.ndarray, ref: np.ndarray) -> np.ndarray:
+def denormalize_signals(sources: ndarray, ref: ndarray) -> ndarray:
     """Scale signals back to the original scale.
 
     Args:
-        sources (np.ndarray): Source to be scaled.
-        ref (np.ndarray): Original sources to be used for reverting scaling.
+        sources (ndarray): Source to be scaled.
+        ref (ndarray): Original sources to be used for reverting scaling.
 
     Returns:
-        np.ndarray: Signal rescaled back to its original."""
+        ndarray: Signal rescaled back to its original."""
     return sources * ref.std() + ref.mean()
 
 
-def normalize_signal(signal: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def normalize_signal(signal: ndarray) -> tuple[ndarray, ndarray]:
     """Standardize the signal to have zero mean and unit variance.
 
     Args:
@@ -39,3 +41,20 @@ def normalize_signal(signal: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """
     ref = signal.mean(0)
     return (signal - ref.mean()) / ref.std(), ref
+
+
+def resample(signal: ndarray, sample_rate: float, new_sample_rate: float) -> ndarray:
+    """Resample a signal to a new sample rate.
+
+    Args:
+        signal: The signal to be resampled.
+        sample_rate: The original sample rate.
+        new_sample_rate: The new sample rate.
+    Returns:
+        The resampled signal.
+    """
+    if sample_rate == new_sample_rate:
+        return signal
+    return scipy.signal.resample(
+        signal, int(new_sample_rate * signal.shape[0] / sample_rate)
+    )

--- a/recipes/cec1/baseline/evaluate.py
+++ b/recipes/cec1/baseline/evaluate.py
@@ -12,9 +12,9 @@ from tqdm import tqdm
 from clarity.evaluator.mbstoi.mbstoi import mbstoi
 from clarity.evaluator.mbstoi.mbstoi_utils import find_delay_impulse
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad
 from clarity.utils.audiogram import Audiogram
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 
 def listen(ear, signal, audiogram_l, audiogram_r):

--- a/recipes/cec1/baseline/evaluate.py
+++ b/recipes/cec1/baseline/evaluate.py
@@ -12,8 +12,9 @@ from tqdm import tqdm
 from clarity.evaluator.mbstoi.mbstoi import mbstoi
 from clarity.evaluator.mbstoi.mbstoi_utils import find_delay_impulse
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal, write_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import write_signal
 
 
 def listen(ear, signal, audiogram_l, audiogram_r):

--- a/recipes/cpc1/baseline/run.py
+++ b/recipes/cpc1/baseline/run.py
@@ -12,8 +12,9 @@ from tqdm import tqdm
 from clarity.evaluator.mbstoi.mbstoi import mbstoi
 from clarity.evaluator.mbstoi.mbstoi_utils import find_delay_impulse
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal, write_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import write_signal
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/cpc1/baseline/run.py
+++ b/recipes/cpc1/baseline/run.py
@@ -12,9 +12,9 @@ from tqdm import tqdm
 from clarity.evaluator.mbstoi.mbstoi import mbstoi
 from clarity.evaluator.mbstoi.mbstoi_utils import find_delay_impulse
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad
 from clarity.utils.audiogram import Audiogram
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/cpc1/e029_sheffield/prepare_data.py
+++ b/recipes/cpc1/e029_sheffield/prepare_data.py
@@ -13,13 +13,13 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad
 from clarity.utils.audiogram import Audiogram
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 logger = logging.getLogger(__name__)
 
-targ_fs = 16000
+target_sample_rate = 16000
 
 
 def run_data_split(cfg, track):
@@ -193,13 +193,17 @@ def generate_data_split(
 
             utt, orig_fs = sf.read(wav_file)
             utt_16k = resample(
-                np.array(utt).transpose(), orig_sr=orig_fs, target_sr=targ_fs
+                np.array(utt).transpose(), orig_sr=orig_fs, target_sr=target_sample_rate
             ).transpose()
             duration = (
-                len(utt_16k[2 * targ_fs :, 0]) / targ_fs
+                len(utt_16k[2 * target_sample_rate :, 0]) / target_sample_rate
             )  # Get rid of the first two seconds, as there is no speech
-            sf.write(wav_file_left, utt_16k[2 * targ_fs :, 0], targ_fs)
-            sf.write(wav_file_right, utt_16k[2 * targ_fs :, 1], targ_fs)
+            sf.write(
+                wav_file_left, utt_16k[2 * target_sample_rate :, 0], target_sample_rate
+            )
+            sf.write(
+                wav_file_right, utt_16k[2 * target_sample_rate :, 1], target_sample_rate
+            )
 
             csv_lines_left.append(
                 [snt_id, str(duration), str(wav_file_left), spk_id, wrds]

--- a/recipes/cpc1/e029_sheffield/prepare_data.py
+++ b/recipes/cpc1/e029_sheffield/prepare_data.py
@@ -13,8 +13,9 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal, write_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import write_signal
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/cpc1/e032_sheffield/prepare_data.py
+++ b/recipes/cpc1/e032_sheffield/prepare_data.py
@@ -13,13 +13,13 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad
 from clarity.utils.audiogram import Audiogram
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 logger = logging.getLogger(__name__)
 
-targ_fs = 16000
+target_sample_rate = 16000
 
 
 def run_data_split(cfg, track):
@@ -193,13 +193,17 @@ def generate_data_split(
 
             utt, orig_fs = sf.read(wav_file)
             utt_16k = resample(
-                np.array(utt).transpose(), orig_sr=orig_fs, target_sr=targ_fs
+                np.array(utt).transpose(), orig_sr=orig_fs, target_sr=target_sample_rate
             ).transpose()
             duration = (
-                len(utt_16k[2 * targ_fs :, 0]) / targ_fs
+                len(utt_16k[2 * target_sample_rate :, 0]) / target_sample_rate
             )  # Get rid of the first two seconds, as there is no speech
-            sf.write(wav_file_left, utt_16k[2 * targ_fs :, 0], targ_fs)
-            sf.write(wav_file_right, utt_16k[2 * targ_fs :, 1], targ_fs)
+            sf.write(
+                wav_file_left, utt_16k[2 * target_sample_rate :, 0], target_sample_rate
+            )
+            sf.write(
+                wav_file_right, utt_16k[2 * target_sample_rate :, 1], target_sample_rate
+            )
 
             csv_lines_left.append(
                 [snt_id, str(duration), str(wav_file_left), spk_id, wrds]

--- a/recipes/cpc1/e032_sheffield/prepare_data.py
+++ b/recipes/cpc1/e032_sheffield/prepare_data.py
@@ -13,8 +13,9 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal, write_signal
+from clarity.evaluator.msbg.msbg_utils import MSBG_FS, pad, read_signal
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import write_signal
 
 logger = logging.getLogger(__name__)
 

--- a/tests/enhancer/gha/test_gha_interface.py
+++ b/tests/enhancer/gha/test_gha_interface.py
@@ -6,6 +6,7 @@ import pytest
 
 from clarity.enhancer.gha.gha_interface import GHAHearingAid
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import write_signal
 
 
 def setup_ha_and_data(root_path):
@@ -29,9 +30,10 @@ def setup_ha_and_data(root_path):
     ).T  # <- signals are store with channels as columns
 
     for filename in tmp_filenames:
-        gha_hearing_aid.write_signal(
+        write_signal(
             filename,
-            stereo_signal,  # <- signals are store with channels as columns
+            stereo_signal,  # <- signals are stored with channels as columns
+            gha_hearing_aid.sample_rate,
             floating_point=True,
         )
     return gha_hearing_aid, stereo_signal, tmp_filenames
@@ -91,9 +93,10 @@ def test_process_files(mocker, tmp_path):
     # despite that the fact that the file generation is mocked out
     outfile_name = tmp_path / "output.wav"
 
-    gha_hearing_aid.write_signal(
+    write_signal(
         outfile_name,
         np.array([[-0.1, 0.1], [-0.2, 0.2]]),
+        sample_rate=gha_hearing_aid.sample_rate,
         floating_point=True,
     )
 
@@ -126,8 +129,12 @@ def test_write_read_loop(tmp_path, signal, floating_point, strict):
 
     gha_hearing_aid = GHAHearingAid()
 
-    gha_hearing_aid.write_signal(
-        tmp_filename, signal, floating_point=floating_point, strict=strict
+    write_signal(
+        tmp_filename,
+        signal,
+        gha_hearing_aid.sample_rate,
+        floating_point=floating_point,
+        strict=strict,
     )
     result = gha_hearing_aid.read_signal(tmp_filename)
 

--- a/tests/evaluator/msbg/test_msbg_utils.py
+++ b/tests/evaluator/msbg/test_msbg_utils.py
@@ -10,8 +10,8 @@ from clarity.evaluator.msbg.msbg_utils import (
     pad,
     read_gtf_file,
     read_signal,
-    write_signal,
 )
+from clarity.utils.file_io import write_signal
 
 # import scipy
 

--- a/tests/evaluator/msbg/test_msbg_utils.py
+++ b/tests/evaluator/msbg/test_msbg_utils.py
@@ -9,9 +9,8 @@ from clarity.evaluator.msbg.msbg_utils import (
     measure_rms,
     pad,
     read_gtf_file,
-    read_signal,
 )
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 # import scipy
 

--- a/tests/recipes/cec1/baseline/test_enhance.py
+++ b/tests/recipes/cec1/baseline/test_enhance.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig
 
-from clarity.evaluator.msbg.msbg_utils import read_signal, write_signal
+from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import write_signal
 
 # pylint: disable=import-error, no-name-in-module, no-member
 from recipes.cec1.baseline.enhance import enhance

--- a/tests/recipes/cec1/baseline/test_enhance.py
+++ b/tests/recipes/cec1/baseline/test_enhance.py
@@ -8,8 +8,7 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig
 
-from clarity.evaluator.msbg.msbg_utils import read_signal
-from clarity.utils.file_io import write_signal
+from clarity.utils.file_io import read_signal, write_signal
 
 # pylint: disable=import-error, no-name-in-module, no-member
 from recipes.cec1.baseline.enhance import enhance

--- a/tests/recipes/cec1/baseline/test_evaluate.py
+++ b/tests/recipes/cec1/baseline/test_evaluate.py
@@ -11,7 +11,7 @@ from numpy import ndarray
 from omegaconf import DictConfig
 
 import recipes
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 
 # pylint: disable=import-error, no-name-in-module, no-member
 from recipes.cec1.baseline.evaluate import run_calculate_SI, run_HL_processing
@@ -31,15 +31,21 @@ def not_tqdm(iterable):
 def truncated_read_signal(
     filename: str | Path,
     offset: int = 0,
-    nsamples: int = -1,
-    nchannels: int = 0,
+    n_samples: int = -1,
+    n_channels: int = 0,
     offset_is_samples: bool = False,
 ) -> ndarray:
     """Replacement for read signal function.
 
     Returns first 1 second of the signal
     """
-    signal = read_signal(filename, offset, nsamples, nchannels, offset_is_samples)
+    signal = read_signal(
+        filename,
+        offset=offset,
+        n_samples=n_samples,
+        n_channels=n_channels,
+        offset_is_samples=offset_is_samples,
+    )
     # Take 1 second sample from the middle of the signal
     return signal[0:44100, :]
 

--- a/tests/recipes/cec1/baseline/test_evaluate.py
+++ b/tests/recipes/cec1/baseline/test_evaluate.py
@@ -39,15 +39,14 @@ def truncated_read_signal(
 
     Returns first 1 second of the signal
     """
-    signal = read_signal(
+    n_samples = 44100  # <-- take just the first 1 second of the signal
+    return read_signal(
         filename,
         offset=offset,
-        n_samples=n_samples,
         n_channels=n_channels,
+        n_samples=n_samples,
         offset_is_samples=offset_is_samples,
     )
-    # Take 1 second sample from the middle of the signal
-    return signal[0:44100, :]
 
 
 @pytest.fixture()

--- a/tests/recipes/cec1/data_preparation/test_prepare_cec1_data.py
+++ b/tests/recipes/cec1/data_preparation/test_prepare_cec1_data.py
@@ -6,7 +6,7 @@ import hydra
 import numpy as np
 import pytest
 
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 from recipes.cec1.data_preparation import prepare_cec1_data
 
 

--- a/tests/recipes/cec1/e009_sheffield/test_test.py
+++ b/tests/recipes/cec1/e009_sheffield/test_test.py
@@ -9,7 +9,7 @@ import torch
 
 from clarity.enhancer.dnn.mc_conv_tasnet import ConvTasNet
 from clarity.enhancer.dsp.filter import AudiometricFIR
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 from recipes.cec1.e009_sheffield.test import run
 
 

--- a/tests/recipes/cec2/baseline/test_enhance.py
+++ b/tests/recipes/cec2/baseline/test_enhance.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig
 
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 from recipes.cec2.baseline.enhance import enhance
 
 

--- a/tests/recipes/cpc1/baseline/test_run.py
+++ b/tests/recipes/cpc1/baseline/test_run.py
@@ -13,8 +13,8 @@ from scipy.io.wavfile import read
 
 import recipes
 from clarity.evaluator.msbg.msbg import Ear
-from clarity.evaluator.msbg.msbg_utils import read_signal
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import read_signal
 from recipes.cpc1.baseline.run import listen, run, run_calculate_SI, run_HL_processing
 
 

--- a/tests/recipes/icassp_2023/baseline/test_enhance.py
+++ b/tests/recipes/icassp_2023/baseline/test_enhance.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig
 
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 from recipes.icassp_2023.baseline.enhance import enhance
 
 

--- a/tests/recipes/icassp_2023/baseline/test_evaluate.py
+++ b/tests/recipes/icassp_2023/baseline/test_evaluate.py
@@ -11,7 +11,7 @@ import pytest
 from omegaconf import DictConfig
 
 import recipes
-from clarity.evaluator.msbg.msbg_utils import read_signal
+from clarity.utils.file_io import read_signal
 from recipes.icassp_2023.baseline.evaluate import run_calculate_si
 
 

--- a/tests/regression/test_enhancers.py
+++ b/tests/regression/test_enhancers.py
@@ -8,6 +8,7 @@ from clarity.enhancer.dsp import filter  # pylint: disable=redefined-builtin
 from clarity.enhancer.gha.gha_interface import GHAHearingAid as gha
 from clarity.enhancer.gha.gha_utils import format_gaintable, get_gaintable
 from clarity.utils.audiogram import Audiogram
+from clarity.utils.file_io import read_signal
 
 gha_params = {  # hyperparameters for GHA Hearing Aid, BE CAREFUL if making changes
     "sample_rate": 44100,
@@ -65,7 +66,7 @@ def test_GHA_inputs(regtest):
     )
     enhancer.create_HA_inputs(infile_names, merged_filename)
 
-    signal = enhancer.read_signal(merged_filename)
+    signal = read_signal(merged_filename)
     np.set_printoptions(threshold=100)
 
     # outputting a segment not at start to avoid it being all zeros

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -1,7 +1,8 @@
 """Test the file_io module."""
+import numpy as np
 import pytest
 
-from clarity.utils.file_io import read_jsonl, write_jsonl
+from clarity.utils.file_io import read_jsonl, read_signal, write_jsonl, write_signal
 
 
 def test_read_jsonl():
@@ -44,3 +45,169 @@ def test_jsonl_append_read_loop(records, tmp_path):
     write_jsonl(tmp_path / "test2.jsonl", records)
     write_jsonl(tmp_path / "test2.jsonl", records)
     assert read_jsonl(tmp_path / "test2.jsonl") == records + records
+
+
+@pytest.mark.parametrize(
+    "signal, floating_point, strict",
+    [
+        (np.array([1.1, -2.0, 0.0, 44.0, -54.0]), True, True),  # float32
+        (np.array([0.1, -0.2, 0.1, -0.5, 0.99]), False, True),  # int16
+        (np.array([0.1, -0.2, 0.1, -1.00, 0.99]), False, True),  # int16
+        (np.array([0.1, -0.2, 0.1, -1.00, 1.99]), False, False),  # int16
+        (np.array([0.1, -0.2, 0.1, -1.00, 0.99]), False, True),  # int16
+    ],
+)
+def test_write_read_loop(tmp_path, signal, floating_point, strict):
+    """Test write_signal and read_signal"""
+    tmp_filename = tmp_path / "test.wav"
+
+    sample_rate = 16000.0
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=int(sample_rate),  # <-- Sample rate needs to be cast to int
+        floating_point=floating_point,
+        strict=strict,
+    )
+    result = read_signal(tmp_filename, sample_rate=sample_rate)
+
+    # Some precision is lost as convert to int16 and back again
+    assert result.shape == signal.shape
+    # The test where strict is False has overflow which is not caught and hence
+    # reading back the signal has changed
+    if strict:
+        assert result == pytest.approx(signal, abs=1.0 / 16384)
+    else:
+        # Deliberate fail: shows why strict is True is needed
+        assert result != pytest.approx(signal, abs=1.0 / 16384)
+
+
+def test_read_write_multichannel(tmp_path):
+    """Test write_signal and read_signal"""
+    tmp_filename = tmp_path / "test.wav"
+
+    signal = np.ones((2, 10)) * 0.5
+    sample_rate = 16000.0
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=int(sample_rate),  # <-- Sample rate needs to be cast to int
+        floating_point=False,
+        strict=True,
+    )
+    result = read_signal(tmp_filename, sample_rate=sample_rate)
+
+    # Some precision is lost as convert to int16 and back again
+    assert result.shape == signal.shape
+
+
+def test_read_write_sample_mismatch_error(tmp_path):
+    """Should raise an error if the sample rate is not the same"""
+    tmp_filename = tmp_path / "test.wav"
+
+    signal = np.ones((2, 10)) * 0.5
+    sample_rate = 16000.0
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=int(sample_rate),  # <-- Sample rate needs to be cast to int
+        floating_point=False,
+        strict=True,
+    )
+
+    with pytest.raises(ValueError):
+        read_signal(tmp_filename, sample_rate=8000, allow_resample=False)
+
+
+def test_read_write_channel_mismatch(tmp_path):
+    """Should raise an error if the sample rate is not the same"""
+    tmp_filename = tmp_path / "test.wav"
+
+    signal = np.ones((10, 2)) * 0.5
+    sample_rate = 16000.0
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=int(sample_rate),  # <-- Sample rate needs to be cast to int
+        floating_point=False,
+        strict=True,
+    )
+
+    # Correct number of channels - will read OK
+    read_signal(tmp_filename, sample_rate=16000, n_channels=2)
+
+    # Incorrect number of channels - will raise an error
+    with pytest.raises(ValueError):
+        read_signal(tmp_filename, sample_rate=16000, n_channels=1)
+
+
+def test_read_write_sample_with_resample(tmp_path):
+    """Should if the sample rate is not the same and allow_resample is True"""
+    tmp_filename = tmp_path / "test.wav"
+    signal = np.ones((10, 2)) * 0.5
+    sample_rate = 16000.0
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=int(sample_rate),  # <-- Sample rate needs to be cast to int
+        floating_point=False,
+        strict=True,
+    )
+
+    x = read_signal(tmp_filename, sample_rate=8000, allow_resample=True)
+
+    # TODO: read and write is treating channels as columns
+    assert x.shape == (5, 2)
+
+
+def test_write_clipping(tmp_path):
+    """Should raise an error if the sample rate is not the same"""
+    tmp_filename = tmp_path / "test.wav"
+
+    signal = np.ones((10, 2)) * 2.0
+
+    # strict=False, i.e. Clipping allowed - will write OK but log warning
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=16000,
+        floating_point=False,
+        strict=False,
+    )
+
+    # strict=True, i.e. Clipping not allowed - will throw an error
+
+    with pytest.raises(ValueError):
+        write_signal(
+            tmp_filename,
+            signal,
+            sample_rate=16000,
+            floating_point=False,
+            strict=True,
+        )
+
+
+def test_read_write_with_offset(tmp_path):
+    """Should if the sample rate is not the same and allow_resample is True"""
+    tmp_filename = tmp_path / "test.wav"
+    signal = np.ones((10, 2)) * 0.5
+    sample_rate = 10000
+
+    write_signal(
+        tmp_filename,
+        signal,
+        sample_rate=sample_rate,  # <-- Sample rate needs to be cast to int
+        floating_point=False,
+        strict=True,
+    )
+
+    x1 = read_signal(tmp_filename, offset=3, offset_is_samples=True)
+    assert x1.shape == (7, 2)
+
+    x2 = read_signal(tmp_filename, offset=0.0003, offset_is_samples=False)
+    assert x2.shape == (7, 2)

--- a/tests/utils/test_file_io.py
+++ b/tests/utils/test_file_io.py
@@ -83,6 +83,24 @@ def test_write_read_loop(tmp_path, signal, floating_point, strict):
         assert result != pytest.approx(signal, abs=1.0 / 16384)
 
 
+def test_write_mono_as_2D_signal(tmp_path):
+    """Test special case of writing signals for shape [N, 1]"""
+    tmp_filename_1d = tmp_path / "test_1d.wav"
+    tmp_filename_2d = tmp_path / "test_2d.wav"
+    signal_1d = np.ones((10,)) * 0.5
+    signal_2d = np.ones((10, 1)) * 0.5
+
+    write_signal(tmp_filename_1d, signal_1d, sample_rate=16000)
+    write_signal(tmp_filename_2d, signal_2d, sample_rate=16000)
+
+    result_1d = read_signal(tmp_filename_1d)
+    result_2d = read_signal(tmp_filename_2d)
+
+    # Both 1 and 2D signals should be read back as 1D
+    assert result_1d.shape == (10,)
+    assert result_2d.shape == (10,)
+
+
 def test_read_write_multichannel(tmp_path):
     """Test write_signal and read_signal"""
     tmp_filename = tmp_path / "test.wav"
@@ -161,7 +179,6 @@ def test_read_write_sample_with_resample(tmp_path):
 
     x = read_signal(tmp_filename, sample_rate=8000, allow_resample=True)
 
-    # TODO: read and write is treating channels as columns
     assert x.shape == (5, 2)
 
 

--- a/tests/utils/test_signal_processing.py
+++ b/tests/utils/test_signal_processing.py
@@ -6,6 +6,7 @@ from clarity.utils.signal_processing import (
     compute_rms,
     denormalize_signals,
     normalize_signal,
+    resample,
 )
 
 
@@ -135,3 +136,28 @@ def test_compute_rms():
     assert rms == pytest.approx(
         57.803515840, rel=pytest.rel_tolerance, abs=pytest.abs_tolerance
     )
+
+
+@pytest.mark.parametrize(
+    "input_sample_rate, input_shape, output_sample_rate, output_shape",
+    [
+        (16000, (100, 2), 16000, (100, 2)),
+        (16000, (100, 2), 8000, (50, 2)),
+        (16000, (100, 2), 32000, (200, 2)),
+        (16000, (100,), 8000, (50,)),
+        (16000, (100, 1), 8000, (50, 1)),
+        (16000, (100, 2, 3), 8000, (50, 2, 3)),
+        (16000, 100, 8000, (50,)),
+    ],
+)
+def test_resample(input_sample_rate, input_shape, output_sample_rate, output_shape):
+    """Test the signal resampling function"""
+    input_signal = np.ones(input_shape)
+
+    output_signal = resample(
+        signal=input_signal,
+        sample_rate=input_sample_rate,
+        new_sample_rate=output_sample_rate,
+    )
+
+    assert output_signal.shape == output_shape


### PR DESCRIPTION
# Refactoring of audio input and output

Similar functions for reading and writing audio files were previously defined at several points in the library. These have all been replaced by a single pair of functions in utils/file_io that are better documented and provide consistent behaviour.