### PR TITLE
Cad1 fix

### DIFF
--- a/clarity/evaluator/haaqi/haaqi.py
+++ b/clarity/evaluator/haaqi/haaqi.py
@@ -159,8 +159,20 @@ def compute_haaqi(
     audiogram: np.ndarray,
     audiogram_frequencies: np.ndarray,
     sample_rate: int,
+    level1: int = 65,
 ) -> float:
-    """Compute HAAQI metric"""
+    """Compute HAAQI metric
+
+    Args:
+        processed_signal (np.ndarray): Processed signal
+        reference_signal (np.ndarray): Reference signal
+        audiogram (np.ndarray): Audiogram levels
+        audiogram_frequencies (np.ndarray): Audiogram frequencies
+        sample_rate (int): Sample rate
+        level1 (int, optional): Optional input specifying level in dB SPL
+            that corresponds to a signal RMS = 1.
+            Default is 65 dB SPL.
+    """
 
     haaqi_audiogram_frequencies = [250, 500, 1000, 2000, 4000, 6000]
     audiogram_adjusted = np.array(
@@ -177,5 +189,6 @@ def compute_haaqi(
         processed_freq=sample_rate,
         hearing_loss=audiogram_adjusted,
         equalisation=1,
+        level1=level1,
     )
     return score

--- a/clarity/utils/signal_processing.py
+++ b/clarity/utils/signal_processing.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import numpy as np
 
 
+def compute_rms(signal: np.ndarray) -> float:
+    """Compute RMS of signal
+    Args:
+        signal: Signal to compute RMS of.
+    Returns:
+        float: RMS of the signal.
+    """
+    if len(signal) == 0:
+        return 0
+    return np.sqrt(np.mean(np.square(signal)))
+
+
 def normalize_signal(signal: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Standardize the signal to have zero mean and unit variance.
 

--- a/recipes/cad1/task1/baseline/evaluate.py
+++ b/recipes/cad1/task1/baseline/evaluate.py
@@ -1,5 +1,4 @@
 """Evaluate the enhanced signals using the HAAQI metric."""
-# pylint: disable=import-error
 from __future__ import annotations
 
 import csv

--- a/recipes/cad1/task1/baseline/evaluate.py
+++ b/recipes/cad1/task1/baseline/evaluate.py
@@ -1,4 +1,5 @@
 """Evaluate the enhanced signals using the HAAQI metric."""
+# pylint: disable=import-error
 from __future__ import annotations
 
 import csv
@@ -196,7 +197,7 @@ def _evaluate_song_listener(
             np.array(listener_audiograms["audiogram_levels_l"]),
             np.array(listener_audiograms["audiogram_cfs"]),
             config.nalr.fs,
-            65 - 10 * np.log10(compute_rms(left_reference_signal)),
+            65 - 20 * np.log10(compute_rms(left_reference_signal)),
         )
         per_instrument_score[f"right_{instrument}"] = compute_haaqi(
             right_enhanced_signal,
@@ -204,7 +205,7 @@ def _evaluate_song_listener(
             np.array(listener_audiograms["audiogram_levels_r"]),
             np.array(listener_audiograms["audiogram_cfs"]),
             config.nalr.fs,
-            65 - 10 * np.log10(compute_rms(right_reference_signal)),
+            65 - 20 * np.log10(compute_rms(right_reference_signal)),
         )
 
     # Compute the combined score

--- a/recipes/cad1/task1/baseline/evaluate.py
+++ b/recipes/cad1/task1/baseline/evaluate.py
@@ -1,6 +1,7 @@
 """Evaluate the enhanced signals using the HAAQI metric."""
 from __future__ import annotations
 
+# pylint: disable=import-error
 import csv
 import hashlib
 import itertools
@@ -16,9 +17,9 @@ from omegaconf import DictConfig
 from scipy.io import wavfile
 
 from clarity.evaluator.haaqi import compute_haaqi
+from clarity.utils.signal_processing import compute_rms
 
 # pylint: disable=too-many-locals
-# pylint: disable=import-error
 
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,7 @@ def _evaluate_song_listener(
             np.array(listener_audiograms["audiogram_levels_l"]),
             np.array(listener_audiograms["audiogram_cfs"]),
             config.nalr.fs,
+            65 - 10 * np.log10(compute_rms(left_reference_signal)),
         )
         per_instrument_score[f"right_{instrument}"] = compute_haaqi(
             right_enhanced_signal,
@@ -202,6 +204,7 @@ def _evaluate_song_listener(
             np.array(listener_audiograms["audiogram_levels_r"]),
             np.array(listener_audiograms["audiogram_cfs"]),
             config.nalr.fs,
+            65 - 10 * np.log10(compute_rms(right_reference_signal)),
         )
 
     # Compute the combined score

--- a/recipes/cad1/task1/baseline/evaluate.py
+++ b/recipes/cad1/task1/baseline/evaluate.py
@@ -1,7 +1,6 @@
 """Evaluate the enhanced signals using the HAAQI metric."""
 from __future__ import annotations
 
-# pylint: disable=import-error
 import csv
 import hashlib
 import itertools
@@ -20,6 +19,7 @@ from clarity.evaluator.haaqi import compute_haaqi
 from clarity.utils.signal_processing import compute_rms
 
 # pylint: disable=too-many-locals
+# pylint: disable=import-error
 
 
 logger = logging.getLogger(__name__)

--- a/tests/recipes/cad1/task1/test_evaluate.py
+++ b/tests/recipes/cad1/task1/test_evaluate.py
@@ -101,14 +101,14 @@ def test_make_song_listener_list():
                 }
             },
             {
-                "left_drums": 0.149880148,
-                "right_drums": 0.143182857,
-                "left_bass": 0.140449345,
-                "right_bass": 0.181374074,
-                "left_other": 0.132401105,
-                "right_other": 0.164211137,
-                "left_vocals": 0.121260627,
-                "right_vocals": 0.126605279,
+                "left_drums": 0.156074193,
+                "right_drums": 0.144341103,
+                "left_bass": 0.148050589,
+                "right_bass": 0.200470016,
+                "left_other": 0.134118179,
+                "right_other": 0.175471593,
+                "left_vocals": 0.119894038,
+                "right_vocals": 0.1339256182,
             },
         )
     ],
@@ -170,7 +170,7 @@ def test_evaluate_song_listener(
     # Combined score
     assert isinstance(combined_score, float)
     assert combined_score == pytest.approx(
-        0.144920571533222, rel=pytest.rel_tolerance, abs=pytest.abs_tolerance
+        0.15154316655507588, rel=pytest.rel_tolerance, abs=pytest.abs_tolerance
     )
 
     # Per instrument score

--- a/tests/utils/test_signal_processing.py
+++ b/tests/utils/test_signal_processing.py
@@ -1,8 +1,13 @@
 """Test for utils.signal_processing module"""
+# pylint: disable=import-error
 import numpy as np
 import pytest
 
-from clarity.utils.signal_processing import denormalize_signals, normalize_signal
+from clarity.utils.signal_processing import (
+    compute_rms,
+    denormalize_signals,
+    normalize_signal,
+)
 
 
 @pytest.mark.parametrize(
@@ -120,3 +125,14 @@ def test_denormalize_signals(
     assert len(result) == len(expected_result)
     np.testing.assert_array_almost_equal(result[0], expected_result[0])
     np.testing.assert_array_almost_equal(result[1], expected_result[1])
+
+
+def test_compute_rms():
+    """Test the function compute_rms"""
+    np.random.seed(0)
+    sig_len = 600
+    signal = 100 * np.random.random(size=sig_len)
+    rms = compute_rms(signal)
+    assert rms == pytest.approx(
+        57.803515840, rel=pytest.rel_tolerance, abs=pytest.abs_tolerance
+    )

--- a/tests/utils/test_signal_processing.py
+++ b/tests/utils/test_signal_processing.py
@@ -1,5 +1,4 @@
 """Test for utils.signal_processing module"""
-# pylint: disable=import-error
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Hotfix for v0.3.0. Adds `level1` correction to deal with very quiet reference signals. 

Other additions:

- Adds function `compute_rms` in `clarity.utils`
- Adds test function for `compute_rms`
- Add `level1` parameter in `compute_haaqi` function
- Add level1 value when calling `compute_haaqi` in `cad1.task1.baseline.evaluate.py` 