### PR TITLE
316 conflicts in torch devices in torchloudnorm amd convtasnet

### DIFF
--- a/clarity/enhancer/dnn/mc_conv_tasnet.py
+++ b/clarity/enhancer/dnn/mc_conv_tasnet.py
@@ -35,6 +35,8 @@ def overlap_and_add(signal, frame_step, device):
     Based on https://github.com/tensorflow/tensorflow/blob/r1.12/tensorflow/
         contrib/signal/python/ops/reconstruction_ops.py
     """
+    signal = signal.to(device)
+
     outer_dimensions = signal.size()[:-2]
     frames, frame_length = signal.size()[-2:]
 

--- a/clarity/predictor/torch_msbg.py
+++ b/clarity/predictor/torch_msbg.py
@@ -513,13 +513,17 @@ class torchloudnorm(nn.Module):
         block_size: float = 0.4,
         overlap: float = 0.75,
         gamma_a: int = -70,
+        device: str | None = None,
     ) -> None:
         super().__init__()
         self.sample_rate = sample_rate
         self.norm_lufs = norm_lufs
         self.kernel_size = kernel_size
         self.padding = kernel_size // 2
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        if device is None:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        else:
+            self.device = device
 
         # for frequency weighting filters - account for the acoustic respose
         # of the head and auditory system

--- a/clarity/predictor/torch_stoi.py
+++ b/clarity/predictor/torch_stoi.py
@@ -81,11 +81,19 @@ class NegSTOILoss(nn.Module):
 
         # Dependant from FS
         if self.do_resample:
+            print(torchaudio.__version__)
+            if torchaudio.__version__[0] == "0":
+                # For versions v0.x.x
+                resampling_method = "sinc_interpolation"
+            else:
+                # for versions v2.x.x
+                resampling_method = "sinc_interp_hann"
+
             sample_rate = FS
             self.resample = torchaudio.transforms.Resample(
                 orig_freq=self.sample_rate,
                 new_freq=FS,
-                resampling_method="sinc_interp_hann",
+                resampling_method=resampling_method,
             )
         self.win_len = (N_FRAME * sample_rate) // FS
         self.nfft = 2 * self.win_len

--- a/recipes/cec1/e009_sheffield/test.py
+++ b/recipes/cec1/e009_sheffield/test.py
@@ -25,15 +25,21 @@ def run(cfg: DictConfig) -> None:
 
     down_sample = up_sample = None
     if cfg.downsample_factor != 1:
+        if torchaudio.__version__[0] == "0":
+            # For versions v0.x.x
+            resampling_method = "sinc_interpolation"
+        else:
+            # for versions v2.x.x
+            resampling_method = "sinc_interp_hann"
         down_sample = torchaudio.transforms.Resample(
             orig_freq=cfg.sample_rate,
             new_freq=cfg.sample_rate // cfg.downsample_factor,
-            resampling_method="sinc_interp_hann",
+            resampling_method=resampling_method,
         )
         up_sample = torchaudio.transforms.Resample(
             orig_freq=cfg.sample_rate // cfg.downsample_factor,
             new_freq=cfg.sample_rate,
-            resampling_method="sinc_interp_hann",
+            resampling_method=resampling_method,
         )
 
     device = "cuda" if torch.cuda.is_available() else None

--- a/recipes/cec1/e009_sheffield/train.py
+++ b/recipes/cec1/e009_sheffield/train.py
@@ -103,10 +103,16 @@ def train_den(cfg, ear):
     )
     den_module.ear_idx = 0 if ear == "left" else 1
     if cfg.downsample_factor != 1:
+        if torchaudio.__version__[0] == "0":
+            # For versions v0.x.x
+            resampling_method = "sinc_interpolation"
+        else:
+            # for versions v2.x.x
+            resampling_method = "sinc_interp_hann"
         den_module.down_sample = torchaudio.transforms.Resample(
             orig_freq=cfg.sample_rate,
             new_freq=cfg.sample_rate // cfg.downsample_factor,
-            resampling_method="sinc_interp_hann",
+            resampling_method=resampling_method,
         )
 
     # callbacks

--- a/tests/predictor/test_torch_msbg.py
+++ b/tests/predictor/test_torch_msbg.py
@@ -26,6 +26,7 @@ def msbg_model():
     model = MSBGHearingModel(
         audiogram=AUDIOGRAM_MODERATE.levels.tolist(),
         audiometric=AUDIOGRAM_MODERATE.frequencies.tolist(),
+        device="cpu",
     )
     return model
 
@@ -37,6 +38,7 @@ def msbg_model_quick():
         audiogram=AUDIOGRAM_MODERATE.levels.tolist(),
         audiometric=AUDIOGRAM_MODERATE.frequencies.tolist(),
         kernel_size=129,
+        device="cpu",
     )
     return model
 
@@ -49,21 +51,25 @@ def test_msbg_hearing_model_init(use_torch):
     model = MSBGHearingModel(
         audiogram=AUDIOGRAM_MILD.levels.tolist(),
         audiometric=AUDIOGRAM_MILD.frequencies.tolist(),
+        device="cpu",
     )
     assert model.win_len == 441
     model = MSBGHearingModel(
         audiogram=AUDIOGRAM_MODERATE.levels.tolist(),
         audiometric=AUDIOGRAM_MODERATE.frequencies.tolist(),
+        device="cpu",
     )
     assert model.win_len == 441
     model = MSBGHearingModel(
         audiogram=AUDIOGRAM_MODERATE_SEVERE.levels.tolist(),
         audiometric=AUDIOGRAM_MODERATE_SEVERE.frequencies.tolist(),
+        device="cpu",
     )
     assert model.win_len == 441
     model = MSBGHearingModel(
         audiogram=AUDIOGRAM_MODERATE.levels.tolist(),
         audiometric=AUDIOGRAM_MODERATE.frequencies.tolist(),
+        device="cpu",
     )
     assert model.win_len == 441
 
@@ -180,7 +186,9 @@ def test_torchloudnorm_apply_filter(use_torch):
 
     x = torch.randn(2, 1, 40000)
     x = x.cpu()
-    loud_norm = torchloudnorm()
+    loud_norm = torchloudnorm(
+        device="cpu",
+    )
 
     y_torch = loud_norm.apply_filter(x)
     y = y_torch.cpu().detach().numpy()
@@ -196,7 +204,9 @@ def test_torchloudnorm_integrated_loudness(use_torch):
 
     x = torch.randn(2, 1, 20000)
     x = x.cpu()
-    loud_norm = torchloudnorm()
+    loud_norm = torchloudnorm(
+        device="cpu",
+    )
 
     y_torch = loud_norm.integrated_loudness(x)
     y = y_torch.cpu().detach().numpy()
@@ -213,7 +223,9 @@ def test_torchloudnorm_normalise_loudness(use_torch):
     lufs = torch.FloatTensor([[-30.0], [-40.0]]).cpu()
     x = torch.randn(2, 20000)
     x = x.cpu()
-    loud_norm = torchloudnorm()
+    loud_norm = torchloudnorm(
+        device="cpu",
+    )
     y_torch = loud_norm.normalize_loudness(x, lufs=lufs)
     y = y_torch.cpu().detach().numpy()
 
@@ -229,7 +241,9 @@ def test_torchloudnorm_forward(use_torch):
 
     x = torch.randn(2, 20000)
     x = x.cpu()
-    loud_norm = torchloudnorm()
+    loud_norm = torchloudnorm(
+        device="cpu",
+    )
     y_torch = loud_norm.forward(x)  # i.e. sane as `y_torch = loud_norm(x)`
     y = y_torch.cpu().detach().numpy()
     assert y.shape == (2, 20000)

--- a/tests/regression/test_predictors.py
+++ b/tests/regression/test_predictors.py
@@ -63,7 +63,9 @@ def test_torch_msbg_stoi_xeon_e5_2673_cpu(regtest):
 def test_torchloudnorm(regtest):
     torch.manual_seed(0)
     torch.set_num_threads(1)
-    ln = torchloudnorm()
+    ln = torchloudnorm(
+        device="cpu",
+    )
 
     x = torch.randn(2, 44100)
     x = x.cpu()


### PR DESCRIPTION
closes #316 

- Add device parameter in torchloudnorm
- Use the device in add_and_overlap in ConvTasNet
- Selects the resampling method according to the first number of the torchaudio version.
    - V0.xx options are ["sinc_interpolation", "kaiser_window"] 
    - V2.x.x options are [sinc_interp_hann, sinc_interp_kaiser]   