### PR TITLE
For release 0.3.3

### DIFF
--- a/recipes/cad1/README.md
+++ b/recipes/cad1/README.md
@@ -47,16 +47,16 @@ The overall HAAQI score is:
 
 ### Task 2 - Listening music in a car with presence of noise
 
-**The overall HAAQI score is 0.1146.**
+**The overall HAAQI score is 0.1423.**
 
 #### Average HAAQI score per genre
 
 | Genre          | HAAQI  |
 |:---------------|:------:|
-| Classical      | 0.1065 |
-| Hip-Hop        | 0.1196 |
-| Instrumental   | 0.1132 |
-| International  | 0.1112 |
-| Orchestral     | 0.1129 |
-| Pop            | 0.1184 |
-| Rock           | 0.1204 |
+| Classical      | 0.1365 |
+| Hip-Hop        | 0.1462 |
+| Instrumental   | 0.1416 |
+| International  | 0.1432 |
+| Orchestral     | 0.1329 |
+| Pop            | 0.1498 |
+| Rock           | 0.1460 |

--- a/recipes/cad1/task2/baseline/README.md
+++ b/recipes/cad1/task2/baseline/README.md
@@ -140,7 +140,7 @@ Please note: you will not get identical HAAQI scores for the same signals if the
 (in the given recipe, the random seed for each signal is set as the last eight digits of the song md5).
 As there are random noises generated within HAAQI, but the differences should be sufficiently small.
 
-The overall HAAQI score for baseline is **0.1146**.
+The overall HAAQI score for baseline is **0.1423**.
 
 ## 4. References
 

--- a/recipes/cad1/task2/baseline/evaluate.py
+++ b/recipes/cad1/task2/baseline/evaluate.py
@@ -241,9 +241,10 @@ def run_calculate_audio_quality(config: DictConfig) -> None:
     results_file.write_header()
 
     # Initialize acoustic scene model
+    sample_rate_haaqi = 24000
     car_scene_acoustic = CarSceneAcoustics(
         track_duration=30,
-        sample_rate=config.sample_rate,
+        sample_rate=sample_rate_haaqi,
         hrtf_dir=config.path.hrtf_dir,
         config_nalr=config.nalr,
         config_compressor=config.compressor,
@@ -281,12 +282,16 @@ def run_calculate_audio_quality(config: DictConfig) -> None:
         assert enhanced_sample_rate == config.enhanced_sample_rate
 
         # Evaluate scene
-        reference_signal_24k = resample(reference_signal.T, config.sample_rate, 24000)
-        enhanced_signal_24k = resample(enhanced_signal, config.sample_rate, 24000)
+        reference_signal_24k = resample(
+            reference_signal.T, config.sample_rate, sample_rate_haaqi
+        )
+        enhanced_signal_24k = resample(
+            enhanced_signal, enhanced_sample_rate, sample_rate_haaqi
+        )
         aq_score_l, aq_score_r = evaluate_scene(
             reference_signal_24k.T,
             enhanced_signal_24k.T,
-            24000,
+            sample_rate_haaqi,
             scene_id,
             current_scene,
             listener,


### PR DESCRIPTION
I found a typo in Recipe task 2 where the sample rate for the enhanced signal is passed incorrectly.
This originated when we reduced the sample rate of the submission to 32000 Hz

