### PR TITLE
Better Intelligibility metric for CAD2 Task1

### DIFF
--- a/clarity/evaluator/msbg/cochlea.py
+++ b/clarity/evaluator/msbg/cochlea.py
@@ -15,6 +15,7 @@ from clarity.evaluator.msbg.msbg_utils import read_gtf_file
 from clarity.evaluator.msbg.smearing import Smearer
 from clarity.utils.audiogram import Audiogram
 
+
 # TODO: Fix power overflow error when (expansion_ratios[ixch] - 1) < 0
 
 
@@ -224,7 +225,11 @@ class Cochlea:
     """
 
     def __init__(
-        self, audiogram: Audiogram, catch_up_level: float = 105.0, fs: float = 44100.0
+        self,
+        audiogram: Audiogram,
+        catch_up_level: float = 105.0,
+        fs: float = 44100.0,
+        verbose=True,
     ) -> None:
         """Cochlea constructor.
 
@@ -233,6 +238,7 @@ class Cochlea:
             catch_up_level (float, optional): loudness catch-up level in dB
                 Default is 105 dB
             fs (float, optional): sampling frequency
+            verbose (bool, optional): verbose mode. Default is True
 
         """
         self.fs = fs
@@ -254,7 +260,8 @@ class Cochlea:
             r_lower, r_upper = HL_PARAMS[severity_level]["smear_params"]
             self.smearer = Smearer(r_lower, r_upper, fs)
 
-        logging.info("Severity level - %s", severity_level)
+        if verbose:
+            logging.info("Severity level - %s", severity_level)
 
     def simulate(self, coch_sig: ndarray, equiv_0dB_file_SPL: float) -> ndarray:
         """Pass a signal through the cochlea.

--- a/clarity/evaluator/msbg/msbg.py
+++ b/clarity/evaluator/msbg/msbg.py
@@ -40,6 +40,7 @@ class Ear:
         sample_rate: float = 44100.0,
         equiv_0db_spl: float = 100.0,
         ahr: float = 20.0,
+        verbose: bool = False,
     ) -> None:
         """
         Constructor for the Ear class.
@@ -48,7 +49,9 @@ class Ear:
             sample_rate (float): sample frequency.
             equiv_0db_spl (): ???
             ahr (): ???
+            verbose (): ???
         """
+        self.verbose = verbose
         self.sample_rate = sample_rate
         self.src_correction = self.get_src_correction(src_pos)
         self.equiv_0db_spl = equiv_0db_spl
@@ -62,7 +65,7 @@ class Ear:
                 "Impairment too severe: Suggest you limit audiogram max to"
                 "80-90 dB HL, otherwise things go wrong/unrealistic."
             )
-        self.cochlea = Cochlea(audiogram=audiogram)
+        self.cochlea = Cochlea(audiogram=audiogram, verbose=self.verbose)
 
     @staticmethod
     def get_src_correction(src_pos: str) -> ndarray:
@@ -92,6 +95,7 @@ class Ear:
         src_correction: ndarray,
         sample_rate: float,
         backward: bool = False,
+        verbose: bool = True,
     ) -> ndarray:
         """Simulate middle and outer ear transfer functions.
 
@@ -109,12 +113,14 @@ class Ear:
                 or ITU
             sample_rate (int): sampling frequency
             backward (bool, optional): if true then cochlea to src (default: False)
+            verbose (bool, optional): print verbose output (default: True)
 
         Returns:
             np.ndarray: the processed signal
 
         """
-        logging.info("performing outer/middle ear corrections")
+        if verbose:
+            logging.info("performing outer/middle ear corrections")
 
         # make sure that response goes only up to sample_frequency/2
         nyquist = int(sample_rate / 2.0)
@@ -204,7 +210,8 @@ class Ear:
             )
             raise ValueError("Invalid sampling frequency, valid value is 44100")
 
-        logging.info("Processing {len(chans)} samples")
+        if self.verbose:
+            logging.info("Processing {len(chans)} samples")
 
         # Need to know file RMS, and then call that a certain level in SPL:
         # needs some form of pre-measuring.
@@ -219,7 +226,7 @@ class Ear:
 
         # Measure RMS where 3rd arg is dB_rel_rms (how far below)
         calculated_rms, idx, _rel_db_thresh, _active = measure_rms(
-            signal[0], sample_rate, -12
+            signal[0], sample_rate, -12, verbose=self.verbose
         )
 
         # Rescale input data and check level after rescaling
@@ -229,11 +236,11 @@ class Ear:
         new_rms_db = equiv_0db_spl + 10 * np.log10(
             np.mean(np.power(signal[0][idx], 2.0))
         )
-        logging.info(
-            "Rescaling: "
-            f"leveldBSPL was {level_db_spl:3.1f} dB SPL, now {new_rms_db:3.1f} dB SPL. "
-            f" Target SPL is {target_spl:3.1f} dB SPL."
-        )
+        if self.verbose:
+            logging.info(
+                f"Rescaling: leveldBSPL was {level_db_spl:3.1f} dB SPL, now"
+                f" {new_rms_db:3.1f} dB SPL.  Target SPL is {target_spl:3.1f} dB SPL."
+            )
 
         # Add calibration signal at target SPL dB
         if add_calibration is True:
@@ -247,11 +254,17 @@ class Ear:
             signal = np.concatenate((pre_calibration, signal, post_calibration), axis=1)
 
         # Transform from src pos to cochlea, simulate cochlea, transform back to src pos
-        signal = Ear.src_to_cochlea_filt(signal, self.src_correction, sample_rate)
+        signal = Ear.src_to_cochlea_filt(
+            signal, self.src_correction, sample_rate, verbose=self.verbose
+        )
         if self.cochlea is not None:
             signal = np.array([self.cochlea.simulate(x, equiv_0db_spl) for x in signal])
         signal = Ear.src_to_cochlea_filt(
-            signal, self.src_correction, sample_rate, backward=True
+            signal,
+            self.src_correction,
+            sample_rate,
+            backward=True,
+            verbose=self.verbose,
         )
 
         # Implement low-pass filter at top end of audio range: flat to Cutoff freq,

--- a/clarity/evaluator/msbg/msbg.py
+++ b/clarity/evaluator/msbg/msbg.py
@@ -40,7 +40,7 @@ class Ear:
         sample_rate: float = 44100.0,
         equiv_0db_spl: float = 100.0,
         ahr: float = 20.0,
-        verbose: bool = False,
+        verbose: bool = True,
     ) -> None:
         """
         Constructor for the Ear class.

--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -358,6 +358,7 @@ def generate_key_percent(
     threshold_db: float,
     window_length: int,
     percent_to_track: float | None = None,
+    verbose: bool = False,
 ) -> tuple[ndarray, float]:
     """Generate key percent.
     Locates frames above some energy threshold or tracks a certain percentage
@@ -370,6 +371,7 @@ def generate_key_percent(
         window_length (int): length of window in samples.
         percent_to_track (float, optional): Track a percentage of frames.
             Default is None
+        verbose (bool, optional): Print verbose output. Default is False.
 
     Raises:
         ValueError: percent_to_track is set too high.
@@ -393,10 +395,11 @@ def generate_key_percent(
 
     expected = threshold_db
     # new Dec 2003. Possibly track percentage of frames rather than fixed threshold
-    if percent_to_track is not None:
-        logging.info("tracking %s percentage of frames", percent_to_track)
-    else:
-        logging.info("tracking fixed threshold")
+    if verbose:
+        if percent_to_track is not None:
+            logging.info("tracking %s percentage of frames", percent_to_track)
+        else:
+            logging.info("tracking fixed threshold")
 
     # put floor into histogram distribution
     non_zero = np.power(10, (expected - 30) / 10)
@@ -466,6 +469,7 @@ def measure_rms(
     sample_rate: float,
     db_rel_rms: float,
     percent_to_track: float | None = None,
+    verbose=False,
 ) -> tuple[float, ndarray, float, float]:
     """Measure Root Mean Square.
 
@@ -481,6 +485,7 @@ def measure_rms(
         db_rel_rms (float): threshold for frames to track.
         percent_to_track (float, optional): track percentage of frames,
             rather than threshold (default: {None})
+        verbose (bool, optional): Print verbose output. Default is False.
     Returns:
         (tuple): tuple containing
         - rms (float): overall calculated rms (linear)
@@ -500,6 +505,7 @@ def measure_rms(
         key_thr_db,
         round(WIN_SECS * sample_rate),
         percent_to_track=percent_to_track,
+        verbose=verbose,
     )
 
     idx = key.astype(int)  # move into generate_key_percent

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -90,6 +90,7 @@ def compute_intelligibility(
     ear = Ear(
         equiv_0db_spl=equiv_0db_spl,
         sample_rate=sample_rate,
+        verbose=False,
     )
 
     reference = segment_metadata["text"]

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyloudnorm as pyln
 import torch.nn
 import whisper
-from alt_eval import compute_metrics, normalize_lyrics
+from alt_eval import compute_metrics
 from omegaconf import DictConfig
 
 from clarity.enhancer.multiband_compressor import MultibandCompressor
@@ -94,7 +94,6 @@ def compute_intelligibility(
     )
 
     reference = segment_metadata["text"]
-    reference = normalize_lyrics(reference)
     lyrics["reference"] = reference
 
     # Compute left ear
@@ -108,7 +107,6 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False)["text"]
-    hypothesis = normalize_lyrics(hypothesis)
     lyrics["hypothesis_left"] = hypothesis
 
     left_results = compute_metrics(
@@ -126,7 +124,6 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False)["text"]
-    hypothesis = normalize_lyrics(hypothesis)
     lyrics["hypothesis_right"] = hypothesis
 
     right_results = compute_metrics(

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyloudnorm as pyln
 import torch.nn
 import whisper
-from alt_eval import compute_metrics
+from alt_eval import compute_metrics, normalize_lyrics
 from omegaconf import DictConfig
 
 from clarity.enhancer.multiband_compressor import MultibandCompressor
@@ -93,6 +93,7 @@ def compute_intelligibility(
     )
 
     reference = segment_metadata["text"]
+    reference = normalize_lyrics(reference)
     lyrics["reference"] = reference
 
     # Compute left ear
@@ -106,10 +107,11 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False)["text"]
+    hypothesis = normalize_lyrics(hypothesis)
     lyrics["hypothesis_left"] = hypothesis
 
     left_results = compute_metrics(
-        reference, hypothesis, languages="en", include_other=False
+        [reference], [hypothesis], languages="en", include_other=False
     )
 
     # Compute right ear
@@ -123,10 +125,11 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False)["text"]
+    hypothesis = normalize_lyrics(hypothesis)
     lyrics["hypothesis_right"] = hypothesis
 
     right_results = compute_metrics(
-        reference, hypothesis, languages="en", include_other=False
+        [reference], [hypothesis], languages="en", include_other=False
     )
 
     # Compute the average score for both ears

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyloudnorm as pyln
 import torch.nn
 import whisper
-from jiwer import compute_measures
+from alt_eval import compute_metrics
 from omegaconf import DictConfig
 
 from clarity.enhancer.multiband_compressor import MultibandCompressor
@@ -108,7 +108,9 @@ def compute_intelligibility(
     hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False)["text"]
     lyrics["hypothesis_left"] = hypothesis
 
-    left_results = compute_measures(reference, hypothesis)
+    left_results = compute_metrics(
+        reference, hypothesis, languages="en", include_other=False
+    )
 
     # Compute right ear
     ear.set_audiogram(listener.audiogram_right)
@@ -123,7 +125,9 @@ def compute_intelligibility(
     hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False)["text"]
     lyrics["hypothesis_right"] = hypothesis
 
-    right_results = compute_measures(reference, hypothesis)
+    right_results = compute_metrics(
+        reference, hypothesis, languages="en", include_other=False
+    )
 
     # Compute the average score for both ears
     total_words = (


### PR DESCRIPTION
In CAD2 task1, the original intelligibility metric was using whisper for transcription and jiwer for computing correctness.
However, jiwer was used without any normalisation resulting in lower score.
For example, capitalised vs non-capitalised words, punctuations not excluded.

The changes are:

- Replace jiwer by alt-eval which performs several normalisation before calling jiwer.
- Add verbose option True or False for MSGB HL model to reduce unnecessary prints. Warnings will still be printed regardless the verbose option.