### PR TITLE
Better Intelligibility metric for CAD2 Task1

### DIFF
--- a/clarity/evaluator/msbg/cochlea.py
+++ b/clarity/evaluator/msbg/cochlea.py
@@ -15,6 +15,7 @@ from clarity.evaluator.msbg.msbg_utils import read_gtf_file
 from clarity.evaluator.msbg.smearing import Smearer
 from clarity.utils.audiogram import Audiogram
 
+
 # TODO: Fix power overflow error when (expansion_ratios[ixch] - 1) < 0
 
 
@@ -224,7 +225,11 @@ class Cochlea:
     """
 
     def __init__(
-        self, audiogram: Audiogram, catch_up_level: float = 105.0, fs: float = 44100.0
+        self,
+        audiogram: Audiogram,
+        catch_up_level: float = 105.0,
+        fs: float = 44100.0,
+        verbose=True,
     ) -> None:
         """Cochlea constructor.
 
@@ -233,6 +238,7 @@ class Cochlea:
             catch_up_level (float, optional): loudness catch-up level in dB
                 Default is 105 dB
             fs (float, optional): sampling frequency
+            verbose (bool, optional): verbose mode. Default is True
 
         """
         self.fs = fs
@@ -254,7 +260,8 @@ class Cochlea:
             r_lower, r_upper = HL_PARAMS[severity_level]["smear_params"]
             self.smearer = Smearer(r_lower, r_upper, fs)
 
-        logging.info("Severity level - %s", severity_level)
+        if verbose:
+            logging.info("Severity level - %s", severity_level)
 
     def simulate(self, coch_sig: ndarray, equiv_0dB_file_SPL: float) -> ndarray:
         """Pass a signal through the cochlea.

--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -358,6 +358,7 @@ def generate_key_percent(
     threshold_db: float,
     window_length: int,
     percent_to_track: float | None = None,
+    verbose: bool = False,
 ) -> tuple[ndarray, float]:
     """Generate key percent.
     Locates frames above some energy threshold or tracks a certain percentage
@@ -370,6 +371,7 @@ def generate_key_percent(
         window_length (int): length of window in samples.
         percent_to_track (float, optional): Track a percentage of frames.
             Default is None
+        verbose (bool, optional): Print verbose output. Default is False.
 
     Raises:
         ValueError: percent_to_track is set too high.
@@ -393,10 +395,11 @@ def generate_key_percent(
 
     expected = threshold_db
     # new Dec 2003. Possibly track percentage of frames rather than fixed threshold
-    if percent_to_track is not None:
-        logging.info("tracking %s percentage of frames", percent_to_track)
-    else:
-        logging.info("tracking fixed threshold")
+    if verbose:
+        if percent_to_track is not None:
+            logging.info("tracking %s percentage of frames", percent_to_track)
+        else:
+            logging.info("tracking fixed threshold")
 
     # put floor into histogram distribution
     non_zero = np.power(10, (expected - 30) / 10)
@@ -466,6 +469,7 @@ def measure_rms(
     sample_rate: float,
     db_rel_rms: float,
     percent_to_track: float | None = None,
+    verbose: bool = False,
 ) -> tuple[float, ndarray, float, float]:
     """Measure Root Mean Square.
 
@@ -481,6 +485,7 @@ def measure_rms(
         db_rel_rms (float): threshold for frames to track.
         percent_to_track (float, optional): track percentage of frames,
             rather than threshold (default: {None})
+        verbose (bool, optional): Print verbose output. Default is False.
     Returns:
         (tuple): tuple containing
         - rms (float): overall calculated rms (linear)
@@ -500,6 +505,7 @@ def measure_rms(
         key_thr_db,
         round(WIN_SECS * sample_rate),
         percent_to_track=percent_to_track,
+        verbose=verbose,
     )
 
     idx = key.astype(int)  # move into generate_key_percent

--- a/recipes/cad2/task1/requirements.txt
+++ b/recipes/cad2/task1/requirements.txt
@@ -1,4 +1,4 @@
+alt-eval
 huggingface-hub
-jiwer
 openai-whisper
 safetensors


### PR DESCRIPTION
In CAD2 task1, the original intelligibility metric was using whisper for transcription and jiwer for computing correctness.
However, jiwer was used without any normalisation resulting in lower score.
For example, capitalised vs non-capitalised words, punctuations not excluded.

The changes are:

Replace jiwer by alt-eval which performs several normalisation before calling jiwer.
Add verbose option True or False for MSGB HL model to reduce unnecessary prints. Warnings will still be printed regardless the verbose option.