### PR TITLE
set temperature to whisper

### DIFF
--- a/recipes/cad2/task1/baseline/config.yaml
+++ b/recipes/cad2/task1/baseline/config.yaml
@@ -33,6 +33,7 @@ soft_clip: False
 
 evaluate:
   whisper_version: base.en
+  whisper_temperature: 0.0
   set_random_seed: True
   small_test: False
   save_intermediate: False

--- a/recipes/cad2/task1/baseline/config.yaml
+++ b/recipes/cad2/task1/baseline/config.yaml
@@ -33,7 +33,6 @@ soft_clip: False
 
 evaluate:
   whisper_version: base.en
-  whisper_temperature: 0.0
   set_random_seed: True
   small_test: False
   save_intermediate: False

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -70,7 +70,6 @@ def compute_intelligibility(
     save_intermediate: bool = False,
     path_intermediate: str | Path | None = None,
     equiv_0db_spl: float = 100,
-    whisper_temperature: float = 0.0,
 ) -> tuple[float, float, dict]:
     """
     Compute the Intelligibility score for the enhanced signal
@@ -88,7 +87,6 @@ def compute_intelligibility(
         save_intermediate: Save the intermediate signal
         path_intermediate: The path to save the intermediate signal
         equiv_0db_spl: The equivalent 0 dB SPL
-        whisper_temperature: The temperature for the Whisper model
 
     Returns:
         The intelligibility score for the left and right channels
@@ -120,9 +118,9 @@ def compute_intelligibility(
         44100,
         sample_rate,
     )
-    hypothesis = scorer.transcribe(
-        left_path.as_posix(), fp16=False, temperature=whisper_temperature
-    )["text"]
+    hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False, temperature=0.0)[
+        "text"
+    ]
     lyrics["hypothesis_left"] = hypothesis
 
     left_results = compute_metrics(
@@ -139,9 +137,9 @@ def compute_intelligibility(
         44100,
         sample_rate,
     )
-    hypothesis = scorer.transcribe(
-        right_path.as_posix(), fp16=False, temperature=whisper_temperature
-    )["text"]
+    hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False, temperature=0.0)[
+        "text"
+    ]
     lyrics["hypothesis_right"] = hypothesis
 
     right_results = compute_metrics(
@@ -442,7 +440,6 @@ def run_compute_scores(config: DictConfig) -> None:
             path_intermediate=enhanced_signal_path.parent
             / f"{scene_id}_{listener_id}_A{alpha}_remix_hl.flac",
             equiv_0db_spl=config.evaluate.equiv_0db_spl,
-            whisper_temperature=config.evaluate.whisper_temperature,
         )
 
         max_whisper = np.max([whisper_left, whisper_right])

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -137,7 +137,6 @@ def compute_intelligibility(
     right_results = compute_metrics(
         [reference], [hypothesis], languages="en", include_other=False
     )
- 
 
     # Compute the average score for both ears
     total_words = (
@@ -425,8 +424,6 @@ def run_compute_scores(config: DictConfig) -> None:
                 "whisper_be": max_whisper,
                 "alpha": alpha,
                 "score": alpha * max_whisper + (1 - alpha) * np.mean(haaqi_scores),
-
-
             }
         )
 

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -109,12 +109,14 @@ def compute_intelligibility(
     enhanced_left = ear.process(enhanced_signal[:, 0])[0]
     left_path = Path(f"{path_intermediate.as_posix()}_left.flac")
     save_flac_signal(
-        enhanced_signal,
+        enhanced_left,
         left_path,
         44100,
         sample_rate,
     )
-    hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False)["text"]
+    hypothesis = scorer.transcribe(left_path.as_posix(), fp16=False, temperature=0)[
+        "text"
+    ]
     lyrics["hypothesis_left"] = hypothesis
 
     left_results = compute_metrics(
@@ -126,12 +128,14 @@ def compute_intelligibility(
     enhanced_right = ear.process(enhanced_signal[:, 1])[0]
     right_path = Path(f"{path_intermediate.as_posix()}_right.flac")
     save_flac_signal(
-        enhanced_signal,
+        enhanced_right,
         right_path,
         44100,
         sample_rate,
     )
-    hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False)["text"]
+    hypothesis = scorer.transcribe(right_path.as_posix(), fp16=False, temperature=0)[
+        "text"
+    ]
     lyrics["hypothesis_right"] = hypothesis
 
     right_results = compute_metrics(

--- a/recipes/cad2/task1/baseline/evaluate.py
+++ b/recipes/cad2/task1/baseline/evaluate.py
@@ -121,7 +121,7 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(
-        left_path.as_posix(), fp16=False, temperature=whisper_temperature, beam_size=1
+        left_path.as_posix(), fp16=False, temperature=whisper_temperature
     )["text"]
     lyrics["hypothesis_left"] = hypothesis
 
@@ -140,7 +140,7 @@ def compute_intelligibility(
         sample_rate,
     )
     hypothesis = scorer.transcribe(
-        right_path.as_posix(), fp16=False, temperature=whisper_temperature, beam_size=1
+        right_path.as_posix(), fp16=False, temperature=whisper_temperature
     )["text"]
     lyrics["hypothesis_right"] = hypothesis
 


### PR DESCRIPTION
Whisper have a temperature parameter. By default, it uses several values that uses depending on the confident of the transcription. This can result in different transcription every time is run. 
We need to set this to a fix value so the evaluation is fair.

