### PR TITLE
Fix typing of `clarity.evaluator.msbg.msbg_utils.read_gtf_file`

### DIFF
--- a/clarity/evaluator/msbg/msbg_utils.py
+++ b/clarity/evaluator/msbg/msbg_utils.py
@@ -101,15 +101,15 @@ class GTFParamDict(TypedDict):
     BROADEN: float
     SPACING: float
     NGAMMA: int
-    GTnDelays: list[int]
-    GTn_denoms: list[list[float]]
-    GTn_nums: list[list[float]]
-    GTn_CentFrq: list[float]
-    ERBn_CentFrq: list[float]
-    HP_denoms: list[list[float]]
-    HP_nums: list[list[float]]
-    HP_FCorner: list[float]
-    HP_Delays: list[int]
+    GTnDelays: ndarray
+    GTn_denoms: ndarray
+    GTn_nums: ndarray
+    GTn_CentFrq: ndarray
+    ERBn_CentFrq: ndarray
+    HP_denoms: ndarray
+    HP_nums: ndarray
+    HP_FCorner: ndarray
+    HP_Delays: ndarray
     NChans: int
     Start2PoleHP: int
     Recombination_dB: float


### PR DESCRIPTION
The function converts all lists to NumPy arrays, but this was not reflected in its return value.

This fixes a type error in `tests/evaluator/msbg/test_cochlea.py` in modern type checkers such as ty and pytype.