### PR TITLE
Remove deprecated NumPy array to scalar conversion

### DIFF
--- a/clarity/evaluator/haspi/eb.py
+++ b/clarity/evaluator/haspi/eb.py
@@ -1185,9 +1185,9 @@ def group_delay_compensate(
     # Compute the group delay in samples at fsamp for each filter
     _group_delay = np.zeros(nchan)
     for n in range(nchan):
-        _, _group_delay[n] = group_delay(
+        _group_delay[n] = group_delay(
             ([1, a_1[n], a_5[n]], [1, -a_1[n], -a_2[n], -a_3[n], -a_4[n]]), 1
-        )
+        )[1][0]
     _group_delay = np.rint(_group_delay).astype(int)  # convert to integer samples
 
     # Compute the delay correlation

--- a/recipes/cec1/baseline/evaluate.py
+++ b/recipes/cec1/baseline/evaluate.py
@@ -115,13 +115,13 @@ def run_calculate_SI(cfg: DictConfig) -> None:
             logging.info(f"Running SI calculation: scene {scene}, listener {listener}")
             proc = read_signal(proc_folder / f"{scene}_{listener}_HL-output.wav")
             clean = read_signal(
-                Path(cfg.path.scenes_folder) / f"{scene}_target_anechoic.wav"
+                Path(cfg.path.scenes_folder) / f"{scene}_target_anechoic.wav",
             )
             ddf = read_signal(proc_folder / f"{scene}_{listener}_HLddf-output.wav")
 
             # Calculate channel-specific unit impulse delay due to HL model
             # and audiograms
-            delay = find_delay_impulse(ddf, initial_value=int(MSBG_FS / 2))
+            delay = find_delay_impulse(ddf, initial_value=int(MSBG_FS / 2))[:, 0]
             if delay[0] != delay[1]:
                 logging.info(f"Difference in delay of {delay[0] - delay[1]}.")
             max_delay = int(np.max(delay))

--- a/recipes/cpc1/baseline/run.py
+++ b/recipes/cpc1/baseline/run.py
@@ -115,7 +115,7 @@ def run_calculate_SI(cfg, path) -> None:
         ddf = read_signal(proc_folder / f"{scene}_{listener}_{system}_HLddf-output.wav")
 
         # Calculate channel-specific unit impulse delay due to HL model and audiograms
-        delay = find_delay_impulse(ddf, initial_value=int(MSBG_FS / 2))
+        delay = find_delay_impulse(ddf, initial_value=int(MSBG_FS / 2))[:, 0]
         if delay[0] != delay[1]:
             logging.info(f"Difference in delay of {delay[0] - delay[1]}.")
         maxdelay = int(np.max(delay))

--- a/tests/regression/test_full_CEC1_pipeline.py
+++ b/tests/regression/test_full_CEC1_pipeline.py
@@ -161,7 +161,7 @@ def test_full_cec1_pipeline(regtest):
     signal_processed = listen(ear, enhanced_audio, audiogram_left, audiogram_right)
 
     # Calculate channel-specific unit impulse delay due to HL model and audiograms
-    delay = find_delay_impulse(ddf_signal, initial_value=int(MSBG_FS / 2))
+    delay = find_delay_impulse(ddf_signal, initial_value=int(MSBG_FS / 2))[:, 0]
     max_delay = int(np.max(delay))
 
     # Allow for value lower than 1000 samples in case of unimpaired hearing


### PR DESCRIPTION
Running tests right now shows the following deprecation warning:

> DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)

This deprecation is turned into a hard `TypeError` in [NumPy 2.4][np24].

Fix all of these conversions by explicitly indexing into the return values of `scipy.signal.group_delay` and `clarity.evaluator.mbstoi.mbstoi_utils.find_delay_impulse`. Note that the former always returns a `(2, 1)`-sized ndarray, but we shouldn't change the return value as it might affect dependents of this package.

[np24]: https://numpy.org/doc/stable/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar
